### PR TITLE
[Fixes #538] rseq return nil for empty vectors

### DIFF
--- a/src/erl/lang/collections/clojerl.Vector.erl
+++ b/src/erl/lang/collections/clojerl.Vector.erl
@@ -192,7 +192,10 @@ do_reduce(_F, Acc, _Index, _Size, _Array) ->
 %% clojerl.IReduce
 
 rseq(#{?TYPE := ?M, array := Array}) ->
-  'clojerl.Vector.RSeq':?CONSTRUCTOR(Array, array:size(Array) - 1).
+  case array:size(Array) of
+    0 -> ?NIL;
+    _ -> 'clojerl.Vector.RSeq':?CONSTRUCTOR(Array, array:size(Array) - 1)
+  end.
 
 %% clojerl.ISequential
 

--- a/test/clojerl_Vector_SUITE.erl
+++ b/test/clojerl_Vector_SUITE.erl
@@ -307,5 +307,6 @@ complete_coverage(_Config) ->
 
   RSeq = 'clojerl.Vector':rseq(NotEmptyVector),
   3    = clj_rt:first(RSeq),
+  ?NIL = 'clojerl.Vector':rseq(EmptyVector),
 
   {comments, ""}.


### PR DESCRIPTION
#538 