### PR TITLE
[Fixes #607] Traverse seq when calling nth for ISequential instead of using to_list

### DIFF
--- a/src/erl/clj_rt.erl
+++ b/src/erl/clj_rt.erl
@@ -146,7 +146,7 @@ nth_from(Coll, N) ->
       end;
     _ ->
       case 'clojerl.ISequential':?SATISFIES(Type) of
-        true  -> clj_utils:nth(N + 1, to_list(Coll));
+        true  -> nth_seq(N, seq(Coll));
         false -> ?ERROR([<<"Can't apply nth to type ">>, Type])
       end
   end.
@@ -162,10 +162,26 @@ nth_from(Coll, N, NotFound) ->
       end;
     _ ->
       case 'clojerl.ISequential':?SATISFIES(Type) of
-        true  -> clj_utils:nth(N + 1, to_list(Coll), NotFound);
+        true  -> nth_seq(N, seq(Coll), NotFound);
         false -> ?ERROR([<<"Can't apply nth to type ">>, Type])
       end
   end.
+
+-spec nth_seq(non_neg_integer(), any()) -> any().
+nth_seq(Index, Seq) when Index < 0; Seq == ?NIL ->
+  ?ERROR(<<"Index out of bounds">>);
+nth_seq(0, Seq) ->
+  first(Seq);
+nth_seq(N, Seq) ->
+  nth_seq(N - 1, next(Seq)).
+
+-spec nth_seq(non_neg_integer(), any(), any()) -> any().
+nth_seq(Index, Seq, NotFound) when Index < 0; Seq == ?NIL ->
+  NotFound;
+nth_seq(0, Seq, _) ->
+  first(Seq);
+nth_seq(N, Seq, NotFound) ->
+  nth_seq(N - 1, next(Seq), NotFound).
 
 -spec 'empty?'(any()) -> boolean().
 'empty?'(?NIL) -> true;

--- a/test/clojerl_LazySeq_SUITE.erl
+++ b/test/clojerl_LazySeq_SUITE.erl
@@ -18,6 +18,7 @@
         , cons/1
         , reduce/1
         , to_erl/1
+        , infinite_seq/1
         , complete_coverage/1
         ]).
 
@@ -195,6 +196,22 @@ to_erl(_Config) ->
 
   {comments, ""}.
 
+-spec infinite_seq(config()) -> result().
+infinite_seq(_Config) ->
+  LazySeq = range(0, infinity),
+  0   = clj_rt:nth(LazySeq, 0),
+  42  = clj_rt:nth(LazySeq, 42),
+
+  0   = clj_rt:nth(LazySeq, 0, foo),
+  42  = clj_rt:nth(LazySeq, 42, foo),
+  foo = clj_rt:nth(LazySeq, -1, foo),
+
+  ct:comment("Negative index generates error"),
+  ok  = try clj_rt:nth(LazySeq, -1), error
+        catch _:_ -> ok end,
+
+  {comments, ""}.
+
 -spec complete_coverage(config()) -> result().
 complete_coverage(_Config) ->
   ?NIL = 'clojerl.LazySeq':'_'(?NIL),
@@ -211,7 +228,7 @@ complete_coverage(_Config) ->
 -spec range(integer(), integer()) -> 'clojerl.LazySeq':type().
 range(Start, End) ->
   Fun = fun
-          ([]) when Start =< End ->
+          ([]) when Start =< End; End == infinity ->
             'clojerl.Cons':?CONSTRUCTOR(Start, range(Start + 1, End));
           ([]) when Start > End ->
             ?NIL


### PR DESCRIPTION
#607