### PR TITLE
[#628] Experiment with better vector implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CLOJERLC := ${CLOJERL} --compile -o ${EBIN}
 benchmark: all
 	${V} cp ${SCRIPTS}/benchmark/result.txt ${SCRIPTS}/benchmark/result.prev.txt
 	${V} (time ${CLOJERL} -m benchmark.benchmark-runner) 2>&1 | tee ${SCRIPTS}/benchmark/result.txt
-	${V} ${CLOJERL} -m benchmark.report ${SCRIPTS}/benchmark/result.txt ${SCRIPTS}/benchmark/result.prev.txt
+	${V} ${CLOJERL} -m benchmark.report ${SCRIPTS}/benchmark/result.txt ${SCRIPTS}/benchmark/result.prev.txt | tee ${SCRIPTS}/benchmark/report.md
 
 CLJ_BENCH=${SCRIPTS}/benchmark/clojure.txt
 CLJE_BENCH=${SCRIPTS}/benchmark/clojerl.txt

--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,9 @@
     }
   , { dev
     , [ { deps
-        , [{eflame, ".*", {git, "https://github.com/jfacorro/eflame", {branch, "various.improvements"}}}]
+        , [ {eflame, ".*", {git, "https://github.com/jfacorro/eflame", {branch, "various.improvements"}}}
+          , {redbug, "1.2.1"}
+          ]
         }
       ]
     }

--- a/scripts/benchmark/report.clje
+++ b/scripts/benchmark/report.clje
@@ -44,6 +44,9 @@
 (defn -main [& [path path-prev]]
   (let [items (make-report (slurp path))
         items-prev (when path-prev
-                     (vals (make-report (slurp path-prev))))
-        result (compare items items-prev)]
-    (print-report result)))
+                     (vals (make-report (slurp path-prev))))]
+    (-> (compare items items-prev)
+        print-report
+        with-out-str
+        (str/replace "-+-" "-|-")
+        println)))

--- a/scripts/benchmark/report.md
+++ b/scripts/benchmark/report.md
@@ -1,0 +1,96 @@
+|                                                                                             :expr |   :runs | :time-prev | :time | :diff | :diff% |
+|---------------------------------------------------------------------------------------------------|---------|------------|-------|-------|--------|
+|                                                  [coll (into [] (range 1000000))], (apply + coll) |       1 |        432 |   255 |  -177 |    -40 |
+|                [v (into [] (range 1000000))], (loop [[x & xs] v] (if-not (nil? xs) (recur xs) x)) |      10 |       3302 |  1980 | -1322 |    -40 |
+|                                                                [], (reduce conj [] (range 40000)) |      10 |        199 |   125 |   -74 |    -37 |
+|                           [[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count [a b c]) | 1000000 |        215 |   154 |   -61 |    -28 |
+|                    [[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vector a b c)) | 1000000 |        212 |   156 |   -56 |    -26 |
+|                                          [xs (vec (range 512))], (last (for [x xs y xs] (+ x y))) |       4 |        719 |   536 |  -183 |    -25 |
+|                                    [coll (reduce conj [] (range (+ 32768 32)))], (conj coll :foo) |  100000 |         34 |    26 |    -8 |    -23 |
+|                                      [coll (reduce conj [] (range 40000))], (assoc coll 123 :foo) |  100000 |         31 |    26 |    -5 |    -16 |
+|                     [[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vec [a b c])) | 1000000 |        336 |   284 |   -52 |    -15 |
+|                                [a (into [] (range 1000000)) b (into [] (range 1000000))], (= a b) |       1 |        214 |   184 |   -30 |    -14 |
+|                                                                        [coll [1 2 3]], (seq coll) | 1000000 |         84 |    76 |    -8 |     -9 |
+|                                         [coll {(quote foo) 1, (quote bar) 2}], ((quote foo) coll) | 1000000 |        247 |   226 |   -21 |     -8 |
+|                                               [coll (into [] (range 1000000))], (reduce + 0 coll) |       1 |        197 |   180 |   -17 |     -8 |
+|                                                              [], (into [] (take 1000) (repeat 1)) |    1000 |       1325 |  1227 |   -98 |     -7 |
+|                                                                     [coll [1 2 3]], (conj coll 4) | 1000000 |        120 |   111 |    -9 |     -7 |
+|                                                                     [], (into [] (repeat 1000 1)) |    1000 |        960 |   888 |   -72 |     -7 |
+|                                                                     [coll "foobar"], (first coll) | 1000000 |        320 |   300 |   -20 |     -6 |
+|                                                                 [xs [1 2 3 4 5]], (apply list xs) | 1000000 |        359 |   338 |   -21 |     -5 |
+|                                                                 [coll (new Foo 1 2)], (:bar coll) | 1000000 |        159 |   151 |    -8 |     -5 |
+|                                                         [], (into [] (take 1000) (iterate inc 0)) |    1000 |       1540 |  1470 |   -70 |     -4 |
+|                                                    [coll [1 2 3]], (satisfies? clojerl.ISeq coll) | 1000000 |         46 |    44 |    -2 |     -4 |
+|                                                         [coll (range 1000000)], (reduce + 0 coll) |       1 |        189 |   181 |    -8 |     -4 |
+|                                       [f (fn [a b c d e f g h i j & more])], (apply f (range 32)) | 1000000 |        624 |   595 |   -29 |     -4 |
+|   [coll (new Foo 1 2)], (loop [i 0 m coll] (if (< i 1000000) (recur (inc i) (assoc m :bar 2)) m)) |       1 |        228 |   220 |    -8 |     -3 |
+|                                                         [], (into [] (take 1000) (cycle [1 2 3])) |    1000 |       1677 |  1616 |   -61 |     -3 |
+|                                                         [coll (new Foo 1 2)], (assoc coll :bar 2) | 1000000 |        227 |   222 |    -5 |     -2 |
+|                                                                                     [], (str "1") | 1000000 |         36 |    35 |    -1 |     -2 |
+|                                                                          [coll [1 2 3]], (coll 0) | 1000000 |         76 |    74 |    -2 |     -2 |
+|                                                                      [coll [1 2 3]], (nth coll 0) | 1000000 |         90 |    88 |    -2 |     -2 |
+|                                                                     [r (range 1000000)], (last r) |       1 |        174 |   169 |    -5 |     -2 |
+|                                                         [coll (new Foo 1 2)], (assoc coll :baz 3) | 1000000 |        376 |   366 |   -10 |     -2 |
+|                                                            [coll (range 500000)], (reduce + coll) |       1 |         90 |    88 |    -2 |     -2 |
+|                                                          [], (reduce + (take 64 (iterate inc 0))) |   10000 |        570 |   564 |    -6 |     -1 |
+|                                                                [coll (tuple 1 2 3)], (nth coll 2) | 1000000 |         67 |    66 |    -1 |     -1 |
+|           [xs (into [] (range 1000000))], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs) |       1 |       1291 |  1276 |   -15 |     -1 |
+|                                                                 [coll (list 1 2 3)], (first coll) | 1000000 |         52 |    51 |    -1 |     -1 |
+|                                                                  [coll (list 1 2 3)], (rest coll) | 1000000 |         75 |    75 |     0 |      0 |
+|                                                                [coll (tuple 1 2 3)], (first coll) | 1000000 |        123 |   123 |     0 |      0 |
+|                                                                                            [], [] | 1000000 |          8 |     8 |     0 |      0 |
+| [coll {:foo 1, :bar 2}], (loop [i 0 m coll] (if (< i 100000) (recur (inc i) (assoc m :foo 2)) m)) |       1 |         22 |    22 |     0 |      0 |
+|                                                                           [], (simple-multi :foo) | 1000000 |        874 |   879 |     5 |      0 |
+|                                               [coll (list 1 2 3)], (satisfies? clojerl.ISeq coll) | 1000000 |         45 |    45 |     0 |      0 |
+|                                                            [], (transduce (take 64) + (repeat 1)) |   10000 |        763 |   764 |     1 |      0 |
+|                                                                     [coll "foobar"], (nth coll 2) | 1000000 |        150 |   150 |     0 |      0 |
+|                                                                                     [], (str nil) | 1000000 |         18 |    18 |     0 |      0 |
+|                                                                  [coll (tuple 1 2 3)], (seq coll) | 1000000 |         55 |    55 |     0 |      0 |
+|                                                                 [s big-str-data], (read-string s) |    1000 |       1590 |  1585 |    -5 |      0 |
+|                                                                              [], (list 1 2 3 4 5) | 1000000 |         28 |    28 |     0 |      0 |
+|                                                                               [x 1], (identity x) | 1000000 |         11 |    11 |     0 |      0 |
+|                                                         [], (transduce (take 64) + (repeat 48 1)) |   10000 |        768 |   763 |    -5 |      0 |
+|                               [xs (range 1000000)], (reduce + 0 (map inc (map inc (map inc xs)))) |       1 |       1019 |  1014 |    -5 |      0 |
+|                                                       [f (fn [a b & more])], (apply f (range 32)) | 1000000 |        594 |   594 |     0 |      0 |
+|                     [xs (range 1000000)], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs) |       1 |       1268 |  1280 |    12 |      0 |
+|                                                 [coll {(quote foo) 1, (quote bar) 2}], (sym coll) | 1000000 |        223 |   223 |     0 |      0 |
+|                                                                                       [], (str 1) | 1000000 |         52 |    53 |     1 |      1 |
+|                                                [coll {:foo 1} ks [:foo]], (update-in coll ks inc) | 1000000 |        892 |   901 |     9 |      1 |
+|                                                                       [coll "foobar"], (seq coll) | 1000000 |        240 |   244 |     4 |      1 |
+|                                                                 [coll (seq [1 2 3])], (rest coll) | 1000000 |         58 |    59 |     1 |      1 |
+|                                                                                 [], (str "1" "2") | 1000000 |        966 |   983 |    17 |      1 |
+|                                                       [], (transduce (take 64) + (cycle [1 2 3])) |   10000 |        979 |  1003 |    24 |      2 |
+|                                     [coll {(quote foo) 1, (quote bar) 2}], (get coll (quote foo)) | 1000000 |        195 |   199 |     4 |      2 |
+|                                                           [], (doall (take 1000 (iterate inc 0))) |    1000 |        779 |   796 |    17 |      2 |
+|                                                            [xs (list 1 2 3 4 5)], (apply list xs) | 1000000 |        281 |   288 |     7 |      2 |
+|                                                       [], (transduce (take 64) + (iterate inc 0)) |   10000 |        873 |   899 |    26 |      2 |
+|                                                        [s "a" f clojure.string/capitalize], (f s) | 1000000 |        439 |   453 |    14 |      3 |
+|                                                                 [coll (seq [1 2 3])], (next coll) | 1000000 |         56 |    58 |     2 |      3 |
+|                                                                                        [], (list) | 1000000 |         28 |    29 |     1 |      3 |
+|                                                                                   [r r], (last r) |       1 |        439 |   456 |    17 |      3 |
+|                                                [xs (range 512)], (last (for [x xs y xs] (+ x y))) |       1 |        136 |   141 |     5 |      3 |
+|                                                           [], (doall (take 1000 (cycle [1 2 3]))) |    1000 |        845 |   876 |    31 |      3 |
+|                                                                [f tuple], (f 1 2 3 4 5 6 7 8 9 0) |  100000 |         30 |    31 |     1 |      3 |
+|                                                                                  [], (list 1 2 3) | 1000000 |         28 |    29 |     1 |      3 |
+|                                                              [coll {:foo 1, :bar 2}], (:foo coll) | 1000000 |        176 |   183 |     7 |      3 |
+|                                                                             [], (str "1" "2" "3") | 1000000 |       1456 |  1528 |    72 |      4 |
+|                                                               [], (reduce + (take 64 (repeat 1))) |   10000 |        475 |   498 |    23 |      4 |
+|                                                                [], (doall (take 1000 (repeat 1))) |    1000 |        570 |   602 |    32 |      5 |
+|                                                                [coll (seq [1 2 3])], (first coll) | 1000000 |         54 |    57 |     3 |      5 |
+|                                                                [coll {:foo 1, :bar 2}], (kw coll) | 1000000 |        174 |   186 |    12 |      6 |
+|                                      [m {:c 3, :b 2, :a 1}], (zipmap (keys m) (map inc (vals m))) |  100000 |        361 |   385 |    24 |      6 |
+|                                                                       [], (doall (repeat 1000 1)) |    1000 |        573 |   614 |    41 |      7 |
+|                                                                              [x true], (pr-str x) |    1000 |         13 |    14 |     1 |      7 |
+|                                                            [], (reduce + (take 64 (repeat 48 1))) |   10000 |        512 |   549 |    37 |      7 |
+|                                                          [coll {:foo 1, :bar 2}], (get coll :foo) | 1000000 |        139 |   149 |    10 |      7 |
+|                                                          [], (reduce + (take 64 (cycle [1 2 3]))) |   10000 |        636 |   697 |    61 |      9 |
+|                                                                  [], (reduce + 0 (repeat 1000 1)) |    1000 |        703 |   781 |    78 |     11 |
+|                                                                       [], (= 1 1 1 1 1 1 1 1 1 0) |  100000 |        145 |   163 |    18 |     12 |
+|                                                             [s "{:foo [1 2 3]}"], (read-string s) |    1000 |         25 |    28 |     3 |     12 |
+|                                                        [coll []], (instance? clojerl.Vector coll) | 1000000 |         24 |    27 |     3 |     12 |
+|                                           [coll (take 100000 (iterate inc 0))], (reduce + 0 coll) |       1 |         97 |   110 |    13 |     13 |
+|                                                                          [], (symbol (quote foo)) | 1000000 |         29 |    33 |     4 |     13 |
+|                                                               [f vector], (f 1 2 3 4 5 6 7 8 9 0) |  100000 |         86 |    98 |    12 |     13 |
+|                                                   [s "aBcDeF" f clojure.string/capitalize], (f s) | 1000000 |       2653 |  3156 |   503 |     18 |
+|                                                                                [x 10], (pr-str x) |    1000 |         14 |    17 |     3 |     21 |
+|                                          [coll (reduce conj [] (range (+ 32768 33)))], (pop coll) |  100000 |         10 |    24 |    14 |    140 |

--- a/scripts/benchmark/result.txt
+++ b/scripts/benchmark/result.txt
@@ -1,174 +1,174 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; VM      =  Erlang/OTP 19 [erts-8.3.5.4]
-;;; Clojure =  0.4.1-1712.7c467a9
+;;; Clojure =  0.4.1-1734.c8a2028
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [x 1], (identity x), 1000000 runs, 11 msecs
 ;; symbol construction
-[], (symbol (quote foo)), 1000000 runs, 29 msecs
+[], (symbol (quote foo)), 1000000 runs, 33 msecs
 
 ;;; instance?
-[coll []], (instance? clojerl.Vector coll), 1000000 runs, 24 msecs
+[coll []], (instance? clojerl.Vector coll), 1000000 runs, 27 msecs
 ;;; satisfies?
 [coll (list 1 2 3)], (satisfies? clojerl.ISeq coll), 1000000 runs, 45 msecs
-[coll [1 2 3]], (satisfies? clojerl.ISeq coll), 1000000 runs, 46 msecs
+[coll [1 2 3]], (satisfies? clojerl.ISeq coll), 1000000 runs, 44 msecs
 
 ;;; tuple & string ops
-[coll "foobar"], (seq coll), 1000000 runs, 240 msecs
-[coll "foobar"], (first coll), 1000000 runs, 320 msecs
+[coll "foobar"], (seq coll), 1000000 runs, 244 msecs
+[coll "foobar"], (first coll), 1000000 runs, 300 msecs
 [coll "foobar"], (nth coll 2), 1000000 runs, 150 msecs
 [coll (tuple 1 2 3)], (seq coll), 1000000 runs, 55 msecs
 [coll (tuple 1 2 3)], (first coll), 1000000 runs, 123 msecs
-[coll (tuple 1 2 3)], (nth coll 2), 1000000 runs, 67 msecs
+[coll (tuple 1 2 3)], (nth coll 2), 1000000 runs, 66 msecs
 
 ;;; list ops
-[coll (list 1 2 3)], (first coll), 1000000 runs, 52 msecs
+[coll (list 1 2 3)], (first coll), 1000000 runs, 51 msecs
 [coll (list 1 2 3)], (rest coll), 1000000 runs, 75 msecs
-[], (list), 1000000 runs, 28 msecs
-[], (list 1 2 3), 1000000 runs, 28 msecs
+[], (list), 1000000 runs, 29 msecs
+[], (list 1 2 3), 1000000 runs, 29 msecs
 
 ;;; vector ops
 [], [], 1000000 runs, 8 msecs
-[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count [a b c]), 1000000 runs, 215 msecs
-[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vec [a b c])), 1000000 runs, 336 msecs
-[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vector a b c)), 1000000 runs, 212 msecs
-[coll [1 2 3]], (nth coll 0), 1000000 runs, 90 msecs
-[coll [1 2 3]], (coll 0), 1000000 runs, 76 msecs
-[coll [1 2 3]], (conj coll 4), 1000000 runs, 120 msecs
-[coll [1 2 3]], (seq coll), 1000000 runs, 84 msecs
-[coll (seq [1 2 3])], (first coll), 1000000 runs, 54 msecs
-[coll (seq [1 2 3])], (rest coll), 1000000 runs, 58 msecs
-[coll (seq [1 2 3])], (next coll), 1000000 runs, 56 msecs
+[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count [a b c]), 1000000 runs, 154 msecs
+[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vec [a b c])), 1000000 runs, 284 msecs
+[[a b c] (take 3 (repeatedly (fn* [] (rand-int 10))))], (count (vector a b c)), 1000000 runs, 156 msecs
+[coll [1 2 3]], (nth coll 0), 1000000 runs, 88 msecs
+[coll [1 2 3]], (coll 0), 1000000 runs, 74 msecs
+[coll [1 2 3]], (conj coll 4), 1000000 runs, 111 msecs
+[coll [1 2 3]], (seq coll), 1000000 runs, 76 msecs
+[coll (seq [1 2 3])], (first coll), 1000000 runs, 57 msecs
+[coll (seq [1 2 3])], (rest coll), 1000000 runs, 59 msecs
+[coll (seq [1 2 3])], (next coll), 1000000 runs, 58 msecs
 
 ;;; large vector ops
-[], (reduce conj [] (range 40000)), 10 runs, 199 msecs
-[coll (reduce conj [] (range (+ 32768 32)))], (conj coll :foo), 100000 runs, 34 msecs
-[coll (reduce conj [] (range 40000))], (assoc coll 123 :foo), 100000 runs, 31 msecs
-[coll (reduce conj [] (range (+ 32768 33)))], (pop coll), 100000 runs, 10 msecs
+[], (reduce conj [] (range 40000)), 10 runs, 125 msecs
+[coll (reduce conj [] (range (+ 32768 32)))], (conj coll :foo), 100000 runs, 26 msecs
+[coll (reduce conj [] (range 40000))], (assoc coll 123 :foo), 100000 runs, 26 msecs
+[coll (reduce conj [] (range (+ 32768 33)))], (pop coll), 100000 runs, 24 msecs
 
 ;;; vector equality
-[a (into [] (range 1000000)) b (into [] (range 1000000))], (= a b), 1 runs, 214 msecs
+[a (into [] (range 1000000)) b (into [] (range 1000000))], (= a b), 1 runs, 184 msecs
 
 ;;; keyword compare
 
 ;;; reduce lazy-seqs, vectors, ranges
-[coll (take 100000 (iterate inc 0))], (reduce + 0 coll), 1 runs, 97 msecs
-[coll (range 1000000)], (reduce + 0 coll), 1 runs, 189 msecs
-[coll (into [] (range 1000000))], (reduce + 0 coll), 1 runs, 197 msecs
+[coll (take 100000 (iterate inc 0))], (reduce + 0 coll), 1 runs, 110 msecs
+[coll (range 1000000)], (reduce + 0 coll), 1 runs, 181 msecs
+[coll (into [] (range 1000000))], (reduce + 0 coll), 1 runs, 180 msecs
 
 ;; apply
-[coll (into [] (range 1000000))], (apply + coll), 1 runs, 432 msecs
+[coll (into [] (range 1000000))], (apply + coll), 1 runs, 255 msecs
 [], (list 1 2 3 4 5), 1000000 runs, 28 msecs
-[xs (list 1 2 3 4 5)], (apply list xs), 1000000 runs, 281 msecs
-[xs [1 2 3 4 5]], (apply list xs), 1000000 runs, 359 msecs
+[xs (list 1 2 3 4 5)], (apply list xs), 1000000 runs, 288 msecs
+[xs [1 2 3 4 5]], (apply list xs), 1000000 runs, 338 msecs
 [f (fn [a b & more])], (apply f (range 32)), 1000000 runs, 594 msecs
-[f (fn [a b c d e f g h i j & more])], (apply f (range 32)), 1000000 runs, 624 msecs
+[f (fn [a b c d e f g h i j & more])], (apply f (range 32)), 1000000 runs, 595 msecs
 
 ;; update-in
-[coll {:foo 1} ks [:foo]], (update-in coll ks inc), 1000000 runs, 892 msecs
+[coll {:foo 1} ks [:foo]], (update-in coll ks inc), 1000000 runs, 901 msecs
 
 ;;; map / record ops
-[coll {:foo 1, :bar 2}], (get coll :foo), 1000000 runs, 139 msecs
-[coll {(quote foo) 1, (quote bar) 2}], (get coll (quote foo)), 1000000 runs, 195 msecs
-[coll {:foo 1, :bar 2}], (:foo coll), 1000000 runs, 176 msecs
-[coll {(quote foo) 1, (quote bar) 2}], ((quote foo) coll), 1000000 runs, 247 msecs
-[coll {:foo 1, :bar 2}], (kw coll), 1000000 runs, 174 msecs
+[coll {:foo 1, :bar 2}], (get coll :foo), 1000000 runs, 149 msecs
+[coll {(quote foo) 1, (quote bar) 2}], (get coll (quote foo)), 1000000 runs, 199 msecs
+[coll {:foo 1, :bar 2}], (:foo coll), 1000000 runs, 183 msecs
+[coll {(quote foo) 1, (quote bar) 2}], ((quote foo) coll), 1000000 runs, 226 msecs
+[coll {:foo 1, :bar 2}], (kw coll), 1000000 runs, 186 msecs
 [coll {(quote foo) 1, (quote bar) 2}], (sym coll), 1000000 runs, 223 msecs
 [coll {:foo 1, :bar 2}], (loop [i 0 m coll] (if (< i 100000) (recur (inc i) (assoc m :foo 2)) m)), 1 runs, 22 msecs
-[coll (new Foo 1 2)], (:bar coll), 1000000 runs, 159 msecs
-[coll (new Foo 1 2)], (assoc coll :bar 2), 1000000 runs, 227 msecs
-[coll (new Foo 1 2)], (assoc coll :baz 3), 1000000 runs, 376 msecs
-[coll (new Foo 1 2)], (loop [i 0 m coll] (if (< i 1000000) (recur (inc i) (assoc m :bar 2)) m)), 1 runs, 228 msecs
+[coll (new Foo 1 2)], (:bar coll), 1000000 runs, 151 msecs
+[coll (new Foo 1 2)], (assoc coll :bar 2), 1000000 runs, 222 msecs
+[coll (new Foo 1 2)], (assoc coll :baz 3), 1000000 runs, 366 msecs
+[coll (new Foo 1 2)], (loop [i 0 m coll] (if (< i 1000000) (recur (inc i) (assoc m :bar 2)) m)), 1 runs, 220 msecs
 
 ;;; zipmap
-[m {:c 3, :b 2, :a 1}], (zipmap (keys m) (map inc (vals m))), 100000 runs, 361 msecs
+[m {:c 3, :b 2, :a 1}], (zipmap (keys m) (map inc (vals m))), 100000 runs, 385 msecs
 
 ;;; seq ops
-[coll (range 500000)], (reduce + coll), 1 runs, 90 msecs
+[coll (range 500000)], (reduce + coll), 1 runs, 88 msecs
 
 ;;; reader
-[s "{:foo [1 2 3]}"], (read-string s), 1000 runs, 25 msecs
-[s big-str-data], (read-string s), 1000 runs, 1590 msecs
+[s "{:foo [1 2 3]}"], (read-string s), 1000 runs, 28 msecs
+[s big-str-data], (read-string s), 1000 runs, 1585 msecs
 
 ;;; range
-[r (range 1000000)], (last r), 1 runs, 174 msecs
+[r (range 1000000)], (last r), 1 runs, 169 msecs
 
 ;;; lazy-seq
 ;;; first run
-[r r], (last r), 1 runs, 440 msecs
+[r r], (last r), 1 runs, 482 msecs
 ;;; second run
-[r r], (last r), 1 runs, 439 msecs
+[r r], (last r), 1 runs, 456 msecs
 
 ;;; comprehensions
-[xs (range 512)], (last (for [x xs y xs] (+ x y))), 1 runs, 136 msecs
-[xs (vec (range 512))], (last (for [x xs y xs] (+ x y))), 4 runs, 719 msecs
+[xs (range 512)], (last (for [x xs y xs] (+ x y))), 1 runs, 141 msecs
+[xs (vec (range 512))], (last (for [x xs y xs] (+ x y))), 4 runs, 536 msecs
 
 ;; reducers
 ;; transducers
-[xs (into [] (range 1000000))], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs), 1 runs, 1291 msecs
+[xs (into [] (range 1000000))], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs), 1 runs, 1276 msecs
 ;; reduce range 1000000 many ops
-[xs (range 1000000)], (reduce + 0 (map inc (map inc (map inc xs)))), 1 runs, 1019 msecs
+[xs (range 1000000)], (reduce + 0 (map inc (map inc (map inc xs)))), 1 runs, 1014 msecs
 ;; transduce range 1000000 many ops 
-[xs (range 1000000)], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs), 1 runs, 1268 msecs
+[xs (range 1000000)], (transduce (comp (map inc) (map inc) (map inc)) + 0 xs), 1 runs, 1280 msecs
 
 
 ;; multimethods
-[], (simple-multi :foo), 1000000 runs, 874 msecs
+[], (simple-multi :foo), 1000000 runs, 879 msecs
 
 
 ;; higher-order variadic function calls
-[f tuple], (f 1 2 3 4 5 6 7 8 9 0), 100000 runs, 30 msecs
-[f vector], (f 1 2 3 4 5 6 7 8 9 0), 100000 runs, 86 msecs
-[], (= 1 1 1 1 1 1 1 1 1 0), 100000 runs, 145 msecs
+[f tuple], (f 1 2 3 4 5 6 7 8 9 0), 100000 runs, 31 msecs
+[f vector], (f 1 2 3 4 5 6 7 8 9 0), 100000 runs, 98 msecs
+[], (= 1 1 1 1 1 1 1 1 1 0), 100000 runs, 163 msecs
 
 
 ;; Destructuring a sequence
-[v (into [] (range 1000000))], (loop [[x & xs] v] (if-not (nil? xs) (recur xs) x)), 10 runs, 3302 msecs
+[v (into [] (range 1000000))], (loop [[x & xs] v] (if-not (nil? xs) (recur xs) x)), 10 runs, 1980 msecs
 
 
 ;;; str
-[], (str 1), 1000000 runs, 52 msecs
+[], (str 1), 1000000 runs, 53 msecs
 [], (str nil), 1000000 runs, 18 msecs
-[], (str "1"), 1000000 runs, 36 msecs
-[], (str "1" "2"), 1000000 runs, 966 msecs
-[], (str "1" "2" "3"), 1000000 runs, 1456 msecs
+[], (str "1"), 1000000 runs, 35 msecs
+[], (str "1" "2"), 1000000 runs, 983 msecs
+[], (str "1" "2" "3"), 1000000 runs, 1528 msecs
 
 
 ;;; clojure.string
-[s "a" f clojure.string/capitalize], (f s), 1000000 runs, 439 msecs
-[s "aBcDeF" f clojure.string/capitalize], (f s), 1000000 runs, 2653 msecs
+[s "a" f clojure.string/capitalize], (f s), 1000000 runs, 453 msecs
+[s "aBcDeF" f clojure.string/capitalize], (f s), 1000000 runs, 3156 msecs
 ;; printing of numbers
-[x true], (pr-str x), 1000 runs, 13 msecs
-[x 10], (pr-str x), 1000 runs, 14 msecs
+[x true], (pr-str x), 1000 runs, 14 msecs
+[x 10], (pr-str x), 1000 runs, 17 msecs
 
 
 ;; cycle
-[], (doall (take 1000 (cycle [1 2 3]))), 1000 runs, 845 msecs
-[], (into [] (take 1000) (cycle [1 2 3])), 1000 runs, 1677 msecs
-[], (reduce + (take 64 (cycle [1 2 3]))), 10000 runs, 636 msecs
-[], (transduce (take 64) + (cycle [1 2 3])), 10000 runs, 979 msecs
+[], (doall (take 1000 (cycle [1 2 3]))), 1000 runs, 876 msecs
+[], (into [] (take 1000) (cycle [1 2 3])), 1000 runs, 1616 msecs
+[], (reduce + (take 64 (cycle [1 2 3]))), 10000 runs, 697 msecs
+[], (transduce (take 64) + (cycle [1 2 3])), 10000 runs, 1003 msecs
 
 
 ;; repeat
-[], (doall (take 1000 (repeat 1))), 1000 runs, 570 msecs
-[], (into [] (take 1000) (repeat 1)), 1000 runs, 1311 msecs
-[], (doall (repeat 1000 1)), 1000 runs, 573 msecs
-[], (into [] (repeat 1000 1)), 1000 runs, 960 msecs
-[], (reduce + 0 (repeat 1000 1)), 1000 runs, 703 msecs
-[], (into [] (take 1000) (repeat 1)), 1000 runs, 1325 msecs
-[], (reduce + (take 64 (repeat 1))), 10000 runs, 475 msecs
-[], (transduce (take 64) + (repeat 1)), 10000 runs, 763 msecs
-[], (reduce + (take 64 (repeat 48 1))), 10000 runs, 512 msecs
-[], (transduce (take 64) + (repeat 48 1)), 10000 runs, 768 msecs
+[], (doall (take 1000 (repeat 1))), 1000 runs, 602 msecs
+[], (into [] (take 1000) (repeat 1)), 1000 runs, 1190 msecs
+[], (doall (repeat 1000 1)), 1000 runs, 614 msecs
+[], (into [] (repeat 1000 1)), 1000 runs, 888 msecs
+[], (reduce + 0 (repeat 1000 1)), 1000 runs, 781 msecs
+[], (into [] (take 1000) (repeat 1)), 1000 runs, 1227 msecs
+[], (reduce + (take 64 (repeat 1))), 10000 runs, 498 msecs
+[], (transduce (take 64) + (repeat 1)), 10000 runs, 764 msecs
+[], (reduce + (take 64 (repeat 48 1))), 10000 runs, 549 msecs
+[], (transduce (take 64) + (repeat 48 1)), 10000 runs, 763 msecs
 
 
 ;; iterate
-[], (doall (take 1000 (iterate inc 0))), 1000 runs, 779 msecs
-[], (into [] (take 1000) (iterate inc 0)), 1000 runs, 1540 msecs
-[], (reduce + (take 64 (iterate inc 0))), 10000 runs, 570 msecs
-[], (transduce (take 64) + (iterate inc 0)), 10000 runs, 873 msecs
+[], (doall (take 1000 (iterate inc 0))), 1000 runs, 796 msecs
+[], (into [] (take 1000) (iterate inc 0)), 1000 runs, 1470 msecs
+[], (reduce + (take 64 (iterate inc 0))), 10000 runs, 564 msecs
+[], (transduce (take 64) + (iterate inc 0)), 10000 runs, 899 msecs
 
 
-real	0m46.895s
-user	0m46.817s
-sys	0m0.330s
+real	0m44.209s
+user	0m44.095s
+sys	0m0.390s

--- a/src/erl/clj_vector.erl
+++ b/src/erl/clj_vector.erl
@@ -1,0 +1,447 @@
+-module(clj_vector).
+
+-include("clojerl.hrl").
+-include("clojerl_int.hrl").
+
+-export([ new/0
+        , new/1
+        , empty/0
+        ]).
+
+-export([ cons/2
+        , reduce/2
+        , reduce/3
+        , get/2
+        , set/3
+        , size/1
+        , to_list/1
+        , tuple_for/2
+        , pop/1
+        ]).
+
+-define(NODE_SIZE, 32).
+-define(MASK, (?NODE_SIZE - 1)).
+-define(SHIFT, 5).
+-define(EMPTY_NODE, { ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    , ?NIL, ?NIL, ?NIL, ?NIL
+                    }
+       ).
+
+-define( EMPTY
+       , #clj_vector{ size    = 0
+                    , shift   = ?SHIFT
+                    , root    = ?EMPTY_NODE
+                    , tail    = ?EMPTY_NODE
+                    , tailoff = 0
+                    }
+       ).
+
+-record(clj_vector, { size   = 0      :: size()
+                    , shift  = ?SHIFT :: shift()
+                    , root            :: tree_node()
+                    , tail            :: tree_node()
+                    , tailoff = 0     :: offset()
+                    }).
+
+-type size()      :: non_neg_integer().
+-type index()     :: non_neg_integer().
+-type shift()     :: non_neg_integer().
+-type tree_node() :: tuple().
+-type offset()    :: non_neg_integer().
+-type vector()    :: #clj_vector{}.
+
+new() ->
+  new([]).
+
+-spec new(list()) -> vector().
+new([]) ->
+  ?EMPTY;
+new(Items) when is_list(Items) ->
+  Length = length(Items),
+  case Length =< ?NODE_SIZE of
+    true ->
+      IndexedValues = index_values_asc(Items, 1, []),
+      Node = erlang:make_tuple(?NODE_SIZE, ?NIL, IndexedValues),
+      cons_node(Node, Length, ?EMPTY);
+    _ ->
+      from_list([], ?NODE_SIZE, ?EMPTY, Items)
+  end.
+
+-spec from_list(list(), index(), vector(), list()) -> vector().
+%% Node list is full with ?NODE_SIZE
+from_list(_NodeList, ?NODE_SIZE, Vector, []) ->
+  Vector;
+from_list(NodeList, 0, Vector0, Items) ->
+  Node = list_to_tuple(lists:reverse(NodeList)),
+  Vector1 = cons_node(Node, ?NODE_SIZE, Vector0),
+  from_list([], ?NODE_SIZE, Vector1, Items);
+%% Node list is not full but there are no more items
+from_list(NodeList, NodeSizeLeft, Vector, []) ->
+  NodeSize = ?NODE_SIZE - NodeSizeLeft,
+  IndexedValues = index_values(NodeList, NodeSize, []),
+  Node = erlang:make_tuple(?NODE_SIZE, ?NIL, IndexedValues),
+  cons_node(Node, NodeSize, Vector);
+from_list(NodeList, NodeSizeLeft, Vector, [Item | Items]) ->
+  from_list([Item | NodeList], NodeSizeLeft - 1, Vector, Items).
+
+-spec index_values(list(), size(), list()) -> list().
+index_values([], _, Acc) ->
+  Acc;
+index_values([X | Rest], N, Acc) ->
+  index_values(Rest, N - 1, [{N, X} | Acc]).
+
+-spec index_values_asc(list(), size(), list()) -> list().
+index_values_asc([], _, Acc) ->
+  Acc;
+index_values_asc([X | Rest], N, Acc) ->
+  index_values_asc(Rest, N + 1, [{N, X} | Acc]).
+
+-spec empty() -> vector().
+empty() -> ?EMPTY.
+
+-spec size(vector()) -> size().
+size(#clj_vector{size = Size}) -> Size.
+
+-spec reduce(function(), vector()) -> any().
+reduce(F, #clj_vector{size = 0}) ->
+  clj_rt:apply(F, []);
+reduce(_F, #clj_vector{size = 1} = Vector) ->
+  get(0, Vector);
+reduce( F
+      , #clj_vector{ size    = Size
+                   , shift   = Shift
+                   , root    = Root
+                   , tail    = Tail
+                   , tailoff = TailOffset
+                   }
+      ) ->
+  Init = element(1, tuple_for(0, Shift, Root, Tail, TailOffset)),
+  reduce_loop(F, Init, 1, Size, Shift, Root, Tail, TailOffset).
+
+-spec reduce(function(), any(), vector()) -> any().
+reduce(_F, Init, #clj_vector{size = 0}) ->
+  Init;
+reduce( F
+      , Init
+      , #clj_vector{ size    = Size
+                   , shift   = Shift
+                   , root    = Root
+                   , tail    = Tail
+                   , tailoff = TailOffset
+                   }
+      ) ->
+  reduce_loop(F, Init, 0, Size, Shift, Root, Tail, TailOffset).
+
+-spec to_list(vector()) -> [any()].
+to_list(#clj_vector{size = 0}) ->
+  [];
+to_list(#clj_vector{ size    = Size
+                   , shift   = Shift
+                   , root    = Root
+                   , tail    = Tail
+                   , tailoff = TailOffset
+                   }
+       ) ->
+  case Size =< ?NODE_SIZE of
+    true  -> to_list_loop_tuple([], Tail, Size);
+    false -> to_list_loop([], Size - 1, Shift, Root, Tail, TailOffset)
+  end.
+
+-spec tuple_for(index(), vector()) -> tree_node().
+tuple_for( Index
+         , #clj_vector{ shift   = Shift
+                      , root    = Root
+                      , tail    = Tail
+                      , tailoff = TailOffset
+                      }) ->
+  tuple_for(Index, Shift, Root, Tail, TailOffset).
+
+-spec cons(any(), vector()) -> vector().
+cons( Value
+    , #clj_vector{ size    = Size
+                 , shift   = Shift
+                 , root    = Root
+                 , tail    = Tail
+                 , tailoff = TailOffset
+                 } = Vector
+    ) ->
+  case Size - TailOffset of
+    %% Space available in the tail
+    Idx when Idx < ?NODE_SIZE ->
+      Vector#clj_vector{ size = Size + 1
+                       , tail = setelement(Idx + 1, Tail, Value)
+                       };
+    %% Root overflow
+    _ when (Size bsr ?SHIFT) > (1 bsl Shift) ->
+      NewPath = new_path(Shift, Tail),
+      InitValues = [{1, Root}, {2, NewPath}],
+      NewRoot = erlang:make_tuple(?NODE_SIZE, ?NIL, InitValues),
+      NewTail = setelement(1, Tail, Value),
+      #clj_vector{ size    = Size + 1
+                 , shift   = Shift + ?SHIFT
+                 , root    = NewRoot
+                 , tail    = NewTail
+                 , tailoff = tailoff(Size + 1)
+                 };
+    %% Otherwise just push the tail
+    _ ->
+      NewRoot = push_tail(Size, Shift, Root, Tail),
+      NewTail = setelement(1, Tail, Value),
+      #clj_vector{ size  = Size + 1
+                 , shift = Shift
+                 , root  = NewRoot
+                 , tail  = NewTail
+                 , tailoff = tailoff(Size + 1)
+                 }
+  end.
+
+-spec get(index(), vector()) -> any().
+get( Index
+   , #clj_vector{ size    = Size
+                , shift   = Shift
+                , root    = Root
+                , tail    = Tail
+                , tailoff = TailOffset
+                }
+   ) when is_integer(Index), Index >= 0, Index < Size ->
+  case Index >= TailOffset of
+    true  ->
+      Idx = Index band ?MASK,
+      element(Idx + 1, Tail);
+    false ->
+      get_from_node(Index, Shift, Root)
+  end;
+get(_Index, _Vector) ->
+  ?ERROR(<<"Index out of bounds">>).
+
+-spec set(index(), any(), vector()) -> vector().
+set( Index
+   , Value
+   , #clj_vector{ size    = Size
+                , shift   = Shift
+                , root    = Root
+                , tail    = Tail
+                , tailoff = TailOffset
+                } = Vector
+   ) when is_integer(Index), Index >= 0, Index < Size ->
+  case Index >= TailOffset of
+    true ->
+      Idx = Index band ?MASK + 1,
+      Vector#clj_vector{tail = setelement(Idx, Tail, Value)};
+    false ->
+      Vector#clj_vector{root = set_new_root(Shift, Root, Index, Value)}
+  end;
+set( Index
+   , Value
+   , #clj_vector{size  = Size} = Vector
+   ) when Index =:= Size ->
+  cons(Value, Vector);
+set(_Index, _Value, _Vector) ->
+  ?ERROR(<<"Index out of bounds">>).
+
+-spec pop(vector()) -> vector().
+pop(#clj_vector{size = 0}) ->
+  ?ERROR(<<"Can't pop empty vector">>);
+pop(#clj_vector{size = 1}) ->
+  ?EMPTY;
+%% Pop from tail
+pop( #clj_vector{ size    = Size
+                , tailoff = TailOffset
+                } = Vector
+   ) when Size - TailOffset > 1 ->
+  Vector#clj_vector{size = Size - 1};
+%% Replace empty tail
+pop( #clj_vector{ size    = Size0
+                , shift   = Shift0
+                , root    = Root0
+                } = Vector
+   ) ->
+  Tail1 = tuple_for_loop(Size0 - 2, Shift0, Root0),
+  Root1 = case pop_tail(Size0, Shift0, Root0) of
+              ?NIL -> ?EMPTY_NODE;
+              X -> X
+            end,
+  {Root2, Shift1} = case Shift0 > 5 andalso element(2, Root1) =:= ?NIL of
+               true  -> {element(1, Root1), Shift0 - 5};
+               false -> {Root1, Shift0}
+             end,
+  Size1 = Size0 - 1,
+  Vector#clj_vector{ size    = Size1
+                   , shift   = Shift1
+                   , root    = Root2
+                   , tail    = Tail1
+                   , tailoff = tailoff(Size1)
+                   }.
+
+%%------------------------------------------------------------------------------
+%% Helper functions
+%%------------------------------------------------------------------------------
+
+-spec new_path(shift(), tree_node()) -> tree_node().
+new_path(_Level = 0, Node) ->
+  Node;
+new_path(Level,  Node) ->
+  NewNode = erlang:make_tuple(?NODE_SIZE, ?NIL),
+  setelement(1, NewNode, new_path(Level - ?SHIFT,  Node)).
+
+-spec push_tail(size(), shift(), tree_node(), tree_node()) ->
+  tree_node().
+push_tail(Size, ?SHIFT, Parent, Tail) ->
+  Idx = ((Size - 1) bsr ?SHIFT) band ?MASK + 1,
+  setelement(Idx, Parent, Tail);
+push_tail(Size, Level, Parent, Tail) ->
+  Idx = ((Size - 1) bsr Level) band ?MASK + 1,
+  NewNode = case element(Idx, Parent) of
+              ?NIL -> new_path(Level - ?SHIFT, Tail);
+              Child -> push_tail(Size, Level - ?SHIFT, Child, Tail)
+            end,
+  setelement(Idx, Parent, NewNode).
+
+-spec tailoff(size()) -> offset().
+tailoff(Size) when Size < ?NODE_SIZE ->
+  0;
+tailoff(Size) ->
+  ((Size - 1) bsr ?SHIFT) bsl ?SHIFT.
+
+-spec get_from_node(index(), shift(), tree_node()) ->
+  any().
+get_from_node(Index, 0, Node) ->
+  Idx = Index band (?NODE_SIZE - 1),
+  element(Idx + 1, Node);
+get_from_node(Index, Level, Node) ->
+  Idx = (Index bsr Level) band ?MASK + 1,
+  get_from_node(Index, Level - ?SHIFT, element(Idx, Node)).
+
+-spec set_new_root(shift(), tree_node(), index(), any()) ->
+  tree_node().
+set_new_root(_Level = 0, Node, Index, Value) ->
+  setelement(Index band ?MASK + 1, Node, Value);
+set_new_root(Level, Node, Index, Value) ->
+  Idx = (Index bsr Level) band ?MASK + 1,
+  Child = set_new_root(Level - ?SHIFT, element(Idx, Node), Index, Value),
+  setelement(Idx, Node, Child).
+
+-spec tuple_for(index(), shift(), tree_node(), tree_node(), offset()) ->
+  tree_node().
+tuple_for(Index, _Shift, _Root, Tail, TailOffset) when Index >= TailOffset ->
+  Tail;
+tuple_for(Index, Shift, Root, _Tail, _TailOffset) ->
+  tuple_for_loop(Index, Shift, Root).
+
+-spec tuple_for_loop(index(), shift(), tree_node()) -> tree_node().
+tuple_for_loop(_Index, 0, Node)->
+  Node;
+tuple_for_loop(Index, Level, Node) ->
+  Idx = (Index bsr Level) band ?MASK + 1,
+  tuple_for_loop(Index, Level - ?SHIFT, element(Idx, Node)).
+
+-spec pop_tail(size(), shift(), tree_node()) -> ?NIL | tree_node().
+pop_tail(Size, Level, Node) ->
+  case ((Size - 2) bsr Level) band ?MASK of
+    0 -> ?NIL;
+    Idx when Level > 5 ->
+      NewChild = pop_tail(Size, Level - ?SHIFT, element(Idx + 1, Node)),
+      setelement(Idx + 1, Node, NewChild);
+    Idx ->
+      setelement(Idx + 1, Node, ?NIL)
+  end.
+
+-spec reduce_loop( any(), any(), index(), size(), shift()
+                 , tree_node(), tree_node(), offset()
+                 ) -> any().
+reduce_loop(F, Acc, CurrentIndex, Size, _Shift, _Root, Tail, TailOffset)
+  when CurrentIndex >= TailOffset ->
+  StartPos = CurrentIndex band ?MASK + 1,
+  EndPos   = Size - TailOffset,
+  case reduce_loop_tuple(F, Acc, Tail, StartPos, EndPos) of
+    {plain, Val} -> Val;
+    {reduced, Reduced} -> 'clojerl.Reduced':deref(Reduced)
+  end;
+reduce_loop(F, Acc0, CurrentIndex, Size, Shift, Root, Tail, TailOffset) ->
+  Tuple      = tuple_for_loop(CurrentIndex, Shift, Root),
+  StartIndex = CurrentIndex band ?MASK,
+  NextIndex  = CurrentIndex + ?NODE_SIZE - StartIndex,
+  StartPos   = StartIndex + 1,
+  case reduce_loop_tuple(F, Acc0, Tuple, StartPos, ?NODE_SIZE) of
+    {plain, Acc1} ->
+      reduce_loop(F, Acc1, NextIndex, Size, Shift, Root, Tail, TailOffset);
+    {reduced, Reduced} ->
+      'clojerl.Reduced':deref(Reduced)
+  end.
+
+-spec reduce_loop_tuple(any(), any(), tree_node(), index(), index()) ->
+  any().
+reduce_loop_tuple(_F, Acc, _Tuple, Current, End) when Current > End ->
+  {plain, Acc};
+reduce_loop_tuple(F, Acc0, Tuple, Current, End) ->
+  Acc1 = clj_rt:apply(F, [Acc0, element(Current, Tuple)]),
+  case 'clojerl.Reduced':is_reduced(Acc1) of
+    true  -> {reduced, Acc1};
+    false -> reduce_loop_tuple(F, Acc1, Tuple, Current + 1, End)
+  end.
+
+-spec to_list_loop( list(), index(), shift(), tree_node()
+                  , tree_node(), offset()
+                  ) -> list().
+to_list_loop(List, Index, _Shift, _Root, _Tail, _TailOffset)
+  when Index < 0 ->
+  List;
+to_list_loop(List, Index, Shift, Root, Tail, TailOffset)
+  when Index >= TailOffset ->
+  Position = Index band ?MASK + 1,
+  List1 = to_list_loop_tuple(List, Tail, Position),
+  to_list_loop(List1,  Index - Position, Shift, Root, Tail, TailOffset);
+to_list_loop(List, Index, Shift, Root, Tail, TailOffset) ->
+  Node = tuple_for_loop(Index, Shift, Root),
+  List1 = to_list_loop_tuple(List, Node, ?NODE_SIZE),
+  to_list_loop(List1,  Index - ?NODE_SIZE, Shift, Root, Tail, TailOffset).
+
+-spec to_list_loop_tuple(list(), tree_node(), index()) -> list().
+to_list_loop_tuple(List, _Node, 0) ->
+  List;
+to_list_loop_tuple(List, Node, Current) ->
+  to_list_loop_tuple([element(Current, Node) | List], Node, Current - 1).
+
+-spec cons_node(any(), size(), vector()) -> vector().
+cons_node(Node, NodeSize, #clj_vector{size = 0} = Vector) ->
+  %% Vector is empty, the node is the tail
+  Vector#clj_vector{size = NodeSize, tail = Node};
+cons_node( Node
+         , NodeSize
+         , #clj_vector{ size    = Size
+                      , shift   = Shift
+                      , root    = Root
+                      , tail    = Tail
+                      }
+         ) when (Size bsr ?SHIFT) > (1 bsl Shift) ->
+  %% Root overflow
+  NewPath = new_path(Shift, Tail),
+  InitValues = [{1, Root}, {2, NewPath}],
+  NewRoot = erlang:make_tuple(?NODE_SIZE, ?NIL, InitValues),
+  #clj_vector{ size    = Size + NodeSize
+             , shift   = Shift + ?SHIFT
+             , root    = NewRoot
+             , tail    = Node
+             , tailoff = tailoff(Size + NodeSize)
+             };
+cons_node( Node
+         , NodeSize
+         , #clj_vector{ size    = Size
+                      , shift   = Shift
+                      , root    = Root
+                      , tail    = Tail
+                      } = Vector
+         ) ->
+  %% Otherwise just push the tail
+  NewRoot = push_tail(Size, Shift, Root, Tail),
+  Vector#clj_vector{ size  = Size + NodeSize
+                   , root  = NewRoot
+                   , tail  = Node
+                   , tailoff = tailoff(Size + NodeSize)
+                   }.

--- a/src/erl/lang/collections/clojerl.Vector.RSeq.erl
+++ b/src/erl/lang/collections/clojerl.Vector.RSeq.erl
@@ -37,12 +37,12 @@
 -export([str/1]).
 
 -type type() :: #{ ?TYPE => ?M
-                 , array => array:array()
+                 , array => clj_vector:vector()
                  , index => integer()
                  , meta  => ?NIL | any()
                  }.
 
--spec ?CONSTRUCTOR(array:array(), integer()) -> type().
+-spec ?CONSTRUCTOR(clj_vector:vector(), integer()) -> type().
 ?CONSTRUCTOR(Array, Index) when Index >= 0 ->
   #{ ?TYPE => ?M
    , array => Array
@@ -104,7 +104,7 @@ with_meta(#{?TYPE := ?M} = X, Meta) ->
 %% clojerl.ISeq
 
 first(#{?TYPE := ?M, index := Index, array := Array}) ->
-  array:get(Index, Array).
+  clj_vector:get(Index, Array).
 
 next(#{?TYPE := ?M, index := Index}) when Index =< 0 -> ?NIL;
 next(#{?TYPE := ?M, index := Index} = X) ->
@@ -129,7 +129,7 @@ to_list(#{?TYPE := ?M, array := Array, index := Index}) ->
 do_to_list(_Array, Current, End, Result) when Current > End ->
   Result;
 do_to_list(Array, Current, End, Result) ->
-  Item = array:get(Current, Array),
+  Item = clj_vector:get(Current, Array),
   do_to_list(Array, Current + 1, End, [Item | Result]).
 
 %% clojerl.IStringable

--- a/test/clojerl_Vector_ChunkedSeq_SUITE.erl
+++ b/test/clojerl_Vector_ChunkedSeq_SUITE.erl
@@ -172,8 +172,8 @@ reduce(_Config) ->
 
   10 = 'clojerl.IReduce':reduce(ChunkedSeq2, PlusMaxFun),
 
-  Array           = array:from_list(lists:seq(0, 32)),
-  EmptyChunkedSeq = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 33),
+  Array           = clj_vector:new(lists:seq(0, 32)),
+  EmptyChunkedSeq = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 32, 1),
 
   0 = 'clojerl.IReduce':reduce(EmptyChunkedSeq, PlusFun, 0),
   0 = 'clojerl.IReduce':reduce(EmptyChunkedSeq, PlusFun),
@@ -187,8 +187,8 @@ to_erl(_Config) ->
   Tuple1      = clj_rt:'->erl'(ChunkedSeq1, false),
   Tuple1      = clj_rt:'->erl'(ChunkedSeq1, true),
 
-  Array            = array:from_list([1, ChunkedSeq1]),
-  ChunkedSeq2      = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 0),
+  Array            = clj_vector:new([1, ChunkedSeq1]),
+  ChunkedSeq2      = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 0, 0),
   {1, ChunkedSeq1} = clj_rt:'->erl'(ChunkedSeq2, false),
   {1, Tuple1}      = clj_rt:'->erl'(ChunkedSeq2, true),
 
@@ -201,8 +201,8 @@ complete_coverage(_Config) ->
   VectorMeta  = clj_rt:with_meta(chunked_seq(64), #{a => 1}),
   #{a := 1} = clj_rt:meta(VectorMeta),
 
-  Array = array:from_list(lists:seq(0, 32)),
-  ChunkedSeq = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 33),
+  Array = clj_vector:new(lists:seq(0, 32)),
+  ChunkedSeq = 'clojerl.Vector.ChunkedSeq':?CONSTRUCTOR(Array, 32, 1),
   ?NIL = clj_rt:seq(ChunkedSeq),
 
   {comments, ""}.

--- a/test/clojerl_Vector_RSeq_SUITE.erl
+++ b/test/clojerl_Vector_RSeq_SUITE.erl
@@ -142,7 +142,7 @@ to_erl(_Config) ->
   List1 = clj_rt:'->erl'(RSeq1, false),
   List1 = clj_rt:'->erl'(RSeq1, true),
 
-  Array = array:from_list([1, RSeq1]),
+  Array = clj_vector:new([1, RSeq1]),
   RSeq2 = 'clojerl.Vector.RSeq':?CONSTRUCTOR(Array, 1),
   [RSeq1, 1] = clj_rt:'->erl'(RSeq2, false),
   [List1, 1] = clj_rt:'->erl'(RSeq2, true),


### PR DESCRIPTION
#628

The benchmark for the `pop` operation results in worse times because it tests the edge case when a node in the tree data structure gets removed. The implementation for `array` in Erlang does not resize the tree when calling `array:resize/2` with a lower number (see [here](https://github.com/erlang/otp/blob/master/lib/stdlib/src/array.erl#L504)).

This is the result of comparing various operations of  `clj_vector` vs. `array`:
```
clje.user=> (foo/compare-creation)
compare-creation with 0
[], (array/from_list coll), 10000 runs, 0 msecs
[], (clj_vector/new coll), 10000 runs, 0 msecs
compare-creation with 100
[], (array/from_list coll), 10000 runs, 28 msecs
[], (clj_vector/new coll), 10000 runs, 28 msecs
compare-creation with 1000
[], (array/from_list coll), 10000 runs, 208 msecs
[], (clj_vector/new coll), 10000 runs, 196 msecs
compare-creation with 10000
[], (array/from_list coll), 10000 runs, 2108 msecs
[], (clj_vector/new coll), 10000 runs, 2189 msecs
nil
clje.user=> (foo/compare-set)
;; compare-set with 33
[x (array/from_list coll)], (array/set 0 :foo x), 10000000 runs, 1152 msecs
[x (clj_vector/new coll)], (clj_vector/set 0 :foo x), 10000000 runs, 1272 msecs
;; compare-set with 1025
[x (array/from_list coll)], (array/set 0 :foo x), 10000000 runs, 2219 msecs
[x (clj_vector/new coll)], (clj_vector/set 0 :foo x), 10000000 runs, 1319 msecs
;; compare-set with 32769
[x (array/from_list coll)], (array/set 0 :foo x), 10000000 runs, 2651 msecs
[x (clj_vector/new coll)], (clj_vector/set 0 :foo x), 10000000 runs, 1558 msecs
nil
clje.user=> (foo/compare-pop)
;; compare-pop with 10
[x (array/from_list coll)], (pop-array x), 100000 runs, 7 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 5 msecs
;; compare-pop with 100
[x (array/from_list coll)], (pop-array x), 100000 runs, 6 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 5 msecs
;; compare-pop with 1000
[x (array/from_list coll)], (pop-array x), 100000 runs, 6 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 5 msecs
;; compare-pop with 32801
[x (array/from_list coll)], (pop-array x), 100000 runs, 7 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 22 msecs
;; compare-pop with 32800
[x (array/from_list coll)], (pop-array x), 100000 runs, 6 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 4 msecs
;; compare-pop with 10000
[x (array/from_list coll)], (pop-array x), 100000 runs, 6 msecs
[x (clj_vector/new coll)], (pop-clj-vector x), 100000 runs, 4 msecs
nil
clje.user=> (foo/compare-reduce)
;; compare-reduce with 10
[x (array/from_list coll)], (array/foldl (erl-fun* :foo :array-plus 3) 0 x), 10000 runs, 46 msecs
[x (clj_vector/new coll)], (clj_vector/reduce erlang/+.2 0 x), 10000 runs, 29 msecs
[x (clj_vector/new coll)], (clj_vector/reduce + 0 x), 10000 runs, 21 msecs
;; compare-reduce with 100
[x (array/from_list coll)], (array/foldl (erl-fun* :foo :array-plus 3) 0 x), 10000 runs, 365 msecs
[x (clj_vector/new coll)], (clj_vector/reduce erlang/+.2 0 x), 10000 runs, 275 msecs
[x (clj_vector/new coll)], (clj_vector/reduce + 0 x), 10000 runs, 209 msecs
;; compare-reduce with 1000
[x (array/from_list coll)], (array/foldl (erl-fun* :foo :array-plus 3) 0 x), 10000 runs, 3558 msecs
[x (clj_vector/new coll)], (clj_vector/reduce erlang/+.2 0 x), 10000 runs, 2714 msecs
[x (clj_vector/new coll)], (clj_vector/reduce + 0 x), 10000 runs, 2082 msecs
nil
clje.user=> (foo/compare-to-list)
;; compare-reduce with 100
[x (array/from_list coll)], (array/to_list x), 10000 runs, 15 msecs
[x (clj_vector/new coll)], (clj_vector/to_list x), 10000 runs, 12 msecs
;; compare-reduce with 1000
[x (array/from_list coll)], (array/to_list x), 10000 runs, 128 msecs
[x (clj_vector/new coll)], (clj_vector/to_list x), 10000 runs, 93 msecs
;; compare-reduce with 10000
[x (array/from_list coll)], (array/to_list x), 10000 runs, 1157 msecs
[x (clj_vector/new coll)], (clj_vector/to_list x), 10000 runs, 987 msecs
nil
```