### PR TITLE
[Closes #661] behaviours

### DIFF
--- a/include/clojerl_int.hrl
+++ b/include/clojerl_int.hrl
@@ -17,6 +17,9 @@
 %% Name for the extends? function in protocols
 -define(EXTENDS, '__extends?__').
 
+%% Name for the callback for behaviors
+-define(BEHAVIOUR_INFO, behaviour_info).
+
 %% Reader constants
 -define(PLATFORM_FEATURES, [clje]).
 -define(RESERVED_FEATURES, [else, none]).

--- a/scripts/protocols/generate.clje
+++ b/scripts/protocols/generate.clje
@@ -239,9 +239,10 @@
 (defn type-ordering
   [[type _]]
   (if (underscore? type)
-    0
+    #erl[0 type]
     (-> (primitive-types type {:order -1})
-        :order)))
+        :order
+        (tuple type))))
 
 (defn module
   [proto-name fns]

--- a/scripts/protocols/generate.clje
+++ b/scripts/protocols/generate.clje
@@ -225,6 +225,17 @@
                    ") -> any().\n")))
        (apply str)))
 
+(defn optional-callbacks
+  [fns]
+  (str "-optional_callbacks(["
+       (->> fns
+            (partition 2)
+            (map (fn [[f args]]
+                   (str "'" f "'/" (count args))))
+            (interpose ", ")
+            (apply str))
+       "]).\n"))
+
 (defn type-ordering
   [[type _]]
   (if (underscore? type)
@@ -258,6 +269,7 @@
          "-export([?SATISFIES/1]).\n"
          "-export([?EXTENDS/1]).\n\n"
          (callbacks fns)
+         (optional-callbacks fns)
          "\n"
          (proto-functions proto-name fns types)
          (satisfies?-function types)

--- a/src/clj/erlang/core.clje
+++ b/src/clj/erlang/core.clje
@@ -4,35 +4,51 @@
 
 (defn- defbehaviour*
   [callbacks]
-  (let [callbacks (->> callbacks
-                      (map (fn [[name args]]
-                             #erl [(keyword name) (count args)]))
-                      ->erl
-                      )]
+  (let [fun-arity      (fn [name] #(tuple (keyword name) (count %)))
+        find-callbacks (fn [[name & arities]]
+                         (map (fun-arity name) arities))
+        find-optional  (fn [[name & arities]]
+                         (->> arities
+                              (filter #(-> % meta :optional))
+                              (map (fun-arity name))))
+        f              #(->> callbacks (map %) (apply concat) ->erl)]
     `(defn* ~'behaviour_info
-       [:callbacks]
-       '~callbacks)))
+       ([:callbacks] '~(f find-callbacks))
+       ([:optional_callbacks] '~(f find-optional)))))
 
 (defmacro defbehaviour
   "Defines Erlang behaviour callbacks for the current ns.
 
   (defbehaviour
     (foo [x])
-    (bar [x y x]))"
+    (bar [x] ^:optional [x y] [x y x]))"
   [& callbacks]
   (defbehaviour* callbacks))
 
 (defn behaviour-callbacks
-  [ns]
+  "Returns a list of callbacks for the provided namespace
+  if it defines.
+  "
+  [ns & [optional?]]
   (let [module (cond
                  (instance? clojerl.Namespace ns)
                  (-> ns ns-name keyword)
 
-                 :else (-> ns name keyword))]
-    (erlang/apply module
-                  :behaviour_info
-                  #erl(:callbacks))))
+                 :else (-> ns name keyword))
+        callback-type (if optional? :optional_callbacks :callbacks)]
+    (try
+      (erlang/apply module
+                    :behaviour_info
+                    #erl(callback-type))
+      (catch _ _
+        ()))))
 
 (defmacro behaviours
+  "Indicate the Erlang behaviours the current ns will implement.
+
+  (behaviours
+    gen_server
+    gen_fsm
+    custom)"
   [& names]
   `(do ~@(map #(list 'behaviour* %) names)))

--- a/src/clj/erlang/core.clje
+++ b/src/clj/erlang/core.clje
@@ -1,4 +1,6 @@
-(ns erlang.core)
+(ns ^{:doc "Erlang core features [EXPERIMENTAL]"
+      :author "Juan Facorro"}
+    erlang.core)
 
 ;;;;;;; behaviour ;;;;;;;;;;;;;
 

--- a/src/clj/erlang/core.clje
+++ b/src/clj/erlang/core.clje
@@ -1,0 +1,38 @@
+(ns erlang.core)
+
+;;;;;;; behaviour ;;;;;;;;;;;;;
+
+(defn- defbehaviour*
+  [callbacks]
+  (let [callbacks (->> callbacks
+                      (map (fn [[name args]]
+                             #erl [(keyword name) (count args)]))
+                      ->erl
+                      )]
+    `(defn* ~'behaviour_info
+       [:callbacks]
+       '~callbacks)))
+
+(defmacro defbehaviour
+  "Defines Erlang behaviour callbacks for the current ns.
+
+  (defbehaviour
+    (foo [x])
+    (bar [x y x]))"
+  [& callbacks]
+  (defbehaviour* callbacks))
+
+(defn behaviour-callbacks
+  [ns]
+  (let [module (cond
+                 (instance? clojerl.Namespace ns)
+                 (-> ns ns-name keyword)
+
+                 :else (-> ns name keyword))]
+    (erlang/apply module
+                  :behaviour_info
+                  #erl(:callbacks))))
+
+(defmacro behaviours
+  [& names]
+  `(do ~@(map #(list 'behaviour* %) names)))

--- a/src/erl/clj_analyzer.erl
+++ b/src/erl/clj_analyzer.erl
@@ -152,6 +152,7 @@ special_forms() ->
    , <<"deftype*">>     => fun parse_deftype/2
    , <<"defprotocol*">> => fun parse_defprotocol/2
    , <<"extend-type*">> => fun parse_extend_type/2
+   , <<"behaviour*">>   => fun parse_behaviour/2
 
    , <<".">>            => fun parse_dot/2
 
@@ -1681,6 +1682,25 @@ analyze_extend_methods([Proto | Methods], {ImplMapAcc, EnvAcc}) ->
   {MethodsExprs, EnvAcc3} = clj_env:last_exprs(length(Methods), EnvAcc2),
 
   {ImplMapAcc#{ProtoExpr => MethodsExprs}, EnvAcc3}.
+
+%%------------------------------------------------------------------------------
+%% Parse behaviour
+%%------------------------------------------------------------------------------
+
+-spec parse_behaviour('clojerl.List':type(), clj_env:env()) -> clj_env:env().
+parse_behaviour(List, Env) ->
+  [ _BehaviourSym % behaviour*
+  , BehaviourName
+  ] = clj_rt:to_list(List),
+
+  BehaviourExpr = #{ op   => behaviour
+                   , env  => Env
+                   , form => List
+                   , tag  => type_expr(?NIL, Env)
+                   , name => BehaviourName
+                   },
+
+  clj_env:push_expr(BehaviourExpr, Env).
 
 %%------------------------------------------------------------------------------
 %% Parse dot

--- a/src/erl/clj_behaviour.erl
+++ b/src/erl/clj_behaviour.erl
@@ -8,16 +8,19 @@
 -spec check(cerl:c_module()) -> ok.
 check(Module) ->
   ExportsAsts = cerl:module_exports(Module),
-  AttrsAsts = cerl:module_attrs(Module),
+  AttrsAsts   = cerl:module_attrs(Module),
+  File        = find_file(AttrsAsts),
 
-  Exports = [extract_fa(E) || E <- ExportsAsts],
-  Behaviours = [extract_behaviour(A) || A <- AttrsAsts, is_behaviour(A)],
-
-  File = find_file(AttrsAsts),
+  Exports     = [extract_fa(E) || E <- ExportsAsts],
+  Behaviours  = [extract_behaviour(A) || A <- AttrsAsts, is_behaviour(A)],
 
   [do_check(File, B, Exports) || B <- Behaviours],
 
   ok.
+
+%%------------------------------------------------------------------------------
+%% Internal
+%%------------------------------------------------------------------------------
 
 -spec extract_fa(cerl:cerl()) -> {atom(), arity()}.
 extract_fa(FunArityAst) ->

--- a/src/erl/clj_behaviour.erl
+++ b/src/erl/clj_behaviour.erl
@@ -1,0 +1,81 @@
+-module(clj_behaviour).
+
+-include("clojerl.hrl").
+-include("clojerl_int.hrl").
+
+-export([check/1]).
+
+-spec check(cerl:c_module()) -> ok.
+check(Module) ->
+  ExportsAsts = cerl:module_exports(Module),
+  AttrsAsts = cerl:module_attrs(Module),
+
+  Exports = [extract_fa(E) || E <- ExportsAsts],
+  Behaviours = [extract_behaviour(A) || A <- AttrsAsts, is_behaviour(A)],
+
+  [do_check(B, Exports) || B <- Behaviours],
+
+  ok.
+
+-spec extract_fa(cerl:cerl()) -> {atom(), arity()}.
+extract_fa(FunArityAst) ->
+  {cerl:fname_id(FunArityAst), cerl:fname_arity(FunArityAst)}.
+
+-spec extract_behaviour({cerl:cerl(), cerl:cerl()}) -> module().
+extract_behaviour({_, ValueAst}) ->
+  [Module] = cerl:concrete(ValueAst),
+  Module.
+
+-spec is_behaviour({cerl:cerl(), cerl:cerl()}) -> boolean().
+is_behaviour({KeyAst, _}) ->
+  Key = cerl:concrete(KeyAst),
+  Key =:= behavior orelse Key =:= behaviour.
+
+-spec do_check(module(), [{atom(), arity()}]) -> ok.
+do_check(Behaviour, Exports) ->
+  Callbacks = sets:from_list(callbacks(Behaviour, callbacks)),
+  Optional  = sets:from_list(callbacks(Behaviour, optional_callbacks)),
+  Required  = sets:subtract(Callbacks, Optional),
+  Missing   = sets:subtract(Required, sets:from_list(Exports)),
+
+  [ ?WARN([ <<"undefined callback function ">>
+          , F, <<"/">>, A
+          , <<" (behaviour ">>, Behaviour, <<")">>
+          ])
+    || {F, A} <- sets:to_list(Missing)
+  ],
+
+  ok.
+
+-spec callbacks(module(), callbacks | optional_callbacks) ->
+  [{atom(), arity()}].
+callbacks(Behavior, Type) ->
+  try
+    case Behavior:behaviour_info(Type) of
+      undefined ->
+        ?WARN_WHEN( Type =:= callbacks
+                  , [<<"Undefined behaviour callbacks">>, Behavior]
+                  ),
+        [];
+      Functions ->
+        case is_fa_list(Functions) of
+          true -> Functions;
+          false ->
+            ?WARN([<<"Ill defined ">>, Type, " in ", Behavior]),
+            []
+        end
+    end
+  catch
+    _:_ ->
+      ?WARN_WHEN( Type =:= callbacks
+                , [<<"Undefined behaviour ">>, Behavior]
+                ),
+      []
+  end.
+
+is_fa_list([{F, A} | L]) when is_atom(F), is_integer(A), A >= 0 ->
+  is_fa_list(L);
+is_fa_list([]) ->
+  true;
+is_fa_list(_) ->
+  false.

--- a/src/erl/clj_compiler.erl
+++ b/src/erl/clj_compiler.erl
@@ -349,11 +349,11 @@ compile_module_fun(Opts) ->
 -spec compile_module(cerl:c_module(), options()) -> binary().
 compile_module(Module, Opts) ->
   ok       = maybe_output_core(Module, Opts),
+  ok       = clj_behaviour:check(Module),
+
   ErlFlags = [ from_core, clint, binary, return_errors, return_warnings
              | maps:get(erl_flags, Opts, [])
              ],
-
-  clj_behaviour:check(Module),
 
   %% io:format("===== Module ====~n~s~n", [core_pp:format(Module)]),
   case compile:noenv_forms(Module, ErlFlags) of

--- a/src/erl/clj_compiler.erl
+++ b/src/erl/clj_compiler.erl
@@ -336,6 +336,8 @@ compile_module(Module, Opts) ->
              | maps:get(erl_flags, Opts, [])
              ],
 
+  clj_behaviour:check(Module),
+
   %% io:format("===== Module ====~n~s~n", [core_pp:format(Module)]),
   case compile:noenv_forms(Module, ErlFlags) of
     {ok, _, Beam0, _Warnings} ->

--- a/src/erl/clj_compiler.erl
+++ b/src/erl/clj_compiler.erl
@@ -17,6 +17,7 @@
         , eval_expressions/1
         , eval_expressions/2
         , compile_module/2
+        , current_file/0
         ]).
 
 -export([ no_warn_dynamic_var_name/1
@@ -217,6 +218,7 @@ do_compile(Src, Opts0, Env0) when is_binary(Src) ->
   CompileFun =
     fun() ->
         try
+          current_file(File),
           Env2  = clj_reader:read_fold(AnnEmitEval, Src, RdrOpts, Time, Env1),
           %% Maybe report time
           Time andalso report_time(Env2),
@@ -233,6 +235,21 @@ do_compile(Src, Opts0, Env0) when is_binary(Src) ->
   Result = clj_module:with_context(CompileFun),
 
   exit(Result).
+
+-define(CURRENT_FILE, '__current_file__').
+
+%% @doc Gets the current file that is being compiled if set
+-spec current_file() -> binary().
+current_file() ->
+   case erlang:get(?CURRENT_FILE) of
+     undefined -> <<?NO_SOURCE>>;
+     X -> X
+   end.
+
+%% @doc Sets the current file that is being compiled
+-spec current_file(binary()) -> ok.
+current_file(Filename) ->
+  erlang:put(?CURRENT_FILE, Filename).
 
 -spec do_eval(any(), options(), clj_env:env()) -> no_return().
 do_eval(Form, Opts0, Env0) ->

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -1444,12 +1444,17 @@ extends_function(Ann) ->
 -spec behaviour_info_function(any(), [{atom(), arity()}]) ->
   {cerl:c_fname(), cerl:c_fun()}.
 behaviour_info_function(Ann, FunArityList) ->
-  Arg         = new_c_var(Ann),
+  Arg          = new_c_var(Ann),
 
-  Callbacks   = cerl:abstract(callbacks),
-  ClauseBody  = cerl:abstract(FunArityList),
-  Clause      = cerl:ann_c_clause(Ann, [Callbacks], ClauseBody),
-  Body        = cerl:ann_c_case(Ann, Arg, [Clause]),
+  ClauseBody   = cerl:abstract(FunArityList),
+
+  Callbacks    = cerl:abstract(callbacks),
+  Clause1      = cerl:ann_c_clause(Ann, [Callbacks], ClauseBody),
+
+  OptCallbacks = cerl:abstract(optional_callbacks),
+  Clause2      = cerl:ann_c_clause(Ann, [OptCallbacks], ClauseBody),
+
+  Body         = cerl:ann_c_case(Ann, Arg, [Clause1, Clause2]),
 
   { cerl:c_fname(?BEHAVIOUR_INFO, 1)
   , cerl:ann_c_fun(Ann, [Arg], Body)

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -437,6 +437,26 @@ ast(#{op := extend_type} = Expr, State) ->
   Ast = cerl:ann_c_atom(ann_from(Env), ?NIL),
   push_ast(Ast, State1#{force_remote_invoke => ForceRemote});
 %%------------------------------------------------------------------------------
+%% behaviour
+%%------------------------------------------------------------------------------
+ast(#{op := behaviour} = Expr, State) ->
+  #{ name := NameSym
+   , env  := Env
+   } = Expr,
+
+  Ann       = ann_from(Env),
+  Name      = to_atom(NameSym),
+  CurrentNs = 'clojerl.Namespace':current(),
+  NsNameSym = 'clojerl.Namespace':name(CurrentNs),
+  Module    = to_atom(NsNameSym),
+  ok        = clj_module:ensure_loaded(file_from(Env), Module),
+
+  BehaviourAttr = {cerl:ann_c_atom(Ann, behavior), cerl:abstract([Name])},
+  clj_module:add_attributes([BehaviourAttr], Module),
+
+  Ast = cerl:ann_c_atom(Ann, ?NIL),
+  push_ast(Ast, State);
+%%------------------------------------------------------------------------------
 %% fn, invoke, erl_fun
 %%------------------------------------------------------------------------------
 ast(#{op := fn} = Expr, State) ->

--- a/src/erl/clj_module.erl
+++ b/src/erl/clj_module.erl
@@ -131,7 +131,8 @@ ensure_loaded(Source, Name) ->
 %% @end
 -spec maybe_ensure_loaded(module()) -> ok.
 maybe_ensure_loaded(Name) ->
-  in_context() andalso ensure_loaded(<<?NO_SOURCE>>, Name),
+  File = clj_compiler:current_file(),
+  in_context() andalso ensure_loaded(File, Name),
   ok.
 
 %% @doc Remove the module from the loaded modules in clj_module.

--- a/src/erl/erlang/erlang.io.ICloseable.erl
+++ b/src/erl/erlang/erlang.io.ICloseable.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'close'(any()) -> any().
+-optional_callbacks(['close'/1]).
 
 'close'(X) ->
   case X of

--- a/src/erl/erlang/erlang.io.ICloseable.erl
+++ b/src/erl/erlang/erlang.io.ICloseable.erl
@@ -15,16 +15,16 @@
 
 'close'(X) ->
   case X of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'close'(X);
     #{?TYPE := 'clojerl.Delay'} ->
       'clojerl.Delay':'close'(X);
-    #{?TYPE := 'erlang.io.StringWriter'} ->
-      'erlang.io.StringWriter':'close'(X);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'close'(X);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'close'(X);
     #{?TYPE := 'erlang.io.StringReader'} ->
       'erlang.io.StringReader':'close'(X);
+    #{?TYPE := 'erlang.io.StringWriter'} ->
+      'erlang.io.StringWriter':'close'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'close', X);
     X_ when erlang:is_binary(X_) ->
@@ -39,11 +39,11 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
     #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
     #{?TYPE := 'erlang.io.File'} ->  true;
+    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
     #{?TYPE := 'erlang.io.StringReader'} ->  true;
+    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -53,10 +53,10 @@
 
 ?EXTENDS(X) ->
   case X of
-    'erlang.io.PushbackReader' -> true;
     'clojerl.Delay' -> true;
-    'erlang.io.StringWriter' -> true;
     'erlang.io.File' -> true;
+    'erlang.io.PushbackReader' -> true;
     'erlang.io.StringReader' -> true;
+    'erlang.io.StringWriter' -> true;
     _ -> false
   end.

--- a/src/erl/erlang/erlang.io.IPushbackReader.erl
+++ b/src/erl/erlang/erlang.io.IPushbackReader.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'unread'(any(), any()) -> any().
+-optional_callbacks(['unread'/2]).
 
 'unread'(Reader, Ch) ->
   case Reader of

--- a/src/erl/erlang/erlang.io.IReader.erl
+++ b/src/erl/erlang/erlang.io.IReader.erl
@@ -18,10 +18,10 @@
 
 'read'(Reader) ->
   case Reader of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'read'(Reader);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'read'(Reader);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'read'(Reader);
     #{?TYPE := 'erlang.io.StringReader'} ->
       'erlang.io.StringReader':'read'(Reader);
     #{?TYPE := _} ->
@@ -40,10 +40,10 @@
 
 'read'(Reader, Length) ->
   case Reader of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'read'(Reader, Length);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'read'(Reader, Length);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'read'(Reader, Length);
     #{?TYPE := 'erlang.io.StringReader'} ->
       'erlang.io.StringReader':'read'(Reader, Length);
     #{?TYPE := _} ->
@@ -62,10 +62,10 @@
 
 'read_line'(Reader) ->
   case Reader of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'read_line'(Reader);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'read_line'(Reader);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'read_line'(Reader);
     #{?TYPE := 'erlang.io.StringReader'} ->
       'erlang.io.StringReader':'read_line'(Reader);
     #{?TYPE := _} ->
@@ -84,10 +84,10 @@
 
 'skip'(Reader, N) ->
   case Reader of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'skip'(Reader, N);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'skip'(Reader, N);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'skip'(Reader, N);
     #{?TYPE := 'erlang.io.StringReader'} ->
       'erlang.io.StringReader':'skip'(Reader, N);
     #{?TYPE := _} ->
@@ -106,8 +106,8 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
     #{?TYPE := 'erlang.io.File'} ->  true;
+    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
     #{?TYPE := 'erlang.io.StringReader'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
@@ -119,8 +119,8 @@
 
 ?EXTENDS(X) ->
   case X of
-    'erlang.io.PushbackReader' -> true;
     'erlang.io.File' -> true;
+    'erlang.io.PushbackReader' -> true;
     'erlang.io.StringReader' -> true;
     'clojerl.Keyword' -> true;
     _ -> false

--- a/src/erl/erlang/erlang.io.IReader.erl
+++ b/src/erl/erlang/erlang.io.IReader.erl
@@ -14,6 +14,7 @@
 -callback 'read'(any(), any()) -> any().
 -callback 'read_line'(any()) -> any().
 -callback 'skip'(any(), any()) -> any().
+-optional_callbacks(['read'/1, 'read'/2, 'read_line'/1, 'skip'/2]).
 
 'read'(Reader) ->
   case Reader of

--- a/src/erl/erlang/erlang.io.IWriter.erl
+++ b/src/erl/erlang/erlang.io.IWriter.erl
@@ -16,10 +16,10 @@
 
 'write'(Writer, Str) ->
   case Writer of
-    #{?TYPE := 'erlang.io.StringWriter'} ->
-      'erlang.io.StringWriter':'write'(Writer, Str);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'write'(Writer, Str);
+    #{?TYPE := 'erlang.io.StringWriter'} ->
+      'erlang.io.StringWriter':'write'(Writer, Str);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'write', Writer);
     X_ when erlang:is_binary(X_) ->
@@ -36,10 +36,10 @@
 
 'write'(Writer, Format, Value) ->
   case Writer of
-    #{?TYPE := 'erlang.io.StringWriter'} ->
-      'erlang.io.StringWriter':'write'(Writer, Format, Value);
     #{?TYPE := 'erlang.io.File'} ->
       'erlang.io.File':'write'(Writer, Format, Value);
+    #{?TYPE := 'erlang.io.StringWriter'} ->
+      'erlang.io.StringWriter':'write'(Writer, Format, Value);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'write', Writer);
     X_ when erlang:is_binary(X_) ->
@@ -56,8 +56,8 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
     #{?TYPE := 'erlang.io.File'} ->  true;
+    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -68,8 +68,8 @@
 
 ?EXTENDS(X) ->
   case X of
-    'erlang.io.StringWriter' -> true;
     'erlang.io.File' -> true;
+    'erlang.io.StringWriter' -> true;
     'clojerl.Keyword' -> true;
     _ -> false
   end.

--- a/src/erl/erlang/erlang.io.IWriter.erl
+++ b/src/erl/erlang/erlang.io.IWriter.erl
@@ -12,6 +12,7 @@
 
 -callback 'write'(any(), any()) -> any().
 -callback 'write'(any(), any(), any()) -> any().
+-optional_callbacks(['write'/2, 'write'/3]).
 
 'write'(Writer, Str) ->
   case Writer of

--- a/src/erl/lang/protocols/clojerl.IAssociative.erl
+++ b/src/erl/lang/protocols/clojerl.IAssociative.erl
@@ -13,6 +13,7 @@
 -callback 'contains_key'(any(), any()) -> any().
 -callback 'entry_at'(any(), any()) -> any().
 -callback 'assoc'(any(), any(), any()) -> any().
+-optional_callbacks(['contains_key'/2, 'entry_at'/2, 'assoc'/3]).
 
 'contains_key'(Assoc, Key) ->
   case Assoc of

--- a/src/erl/lang/protocols/clojerl.IAssociative.erl
+++ b/src/erl/lang/protocols/clojerl.IAssociative.erl
@@ -17,14 +17,14 @@
 
 'contains_key'(Assoc, Key) ->
   case Assoc of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'contains_key'(Assoc, Key);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'contains_key'(Assoc, Key);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'contains_key'(Assoc, Key);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'contains_key'(Assoc, Key);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'contains_key'(Assoc, Key);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'contains_key'(Assoc, Key);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'contains_key', Assoc);
     X_ when erlang:is_binary(X_) ->
@@ -41,14 +41,14 @@
 
 'entry_at'(Assoc, Key) ->
   case Assoc of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'entry_at'(Assoc, Key);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'entry_at'(Assoc, Key);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'entry_at'(Assoc, Key);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'entry_at'(Assoc, Key);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'entry_at'(Assoc, Key);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'entry_at'(Assoc, Key);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'entry_at', Assoc);
     X_ when erlang:is_binary(X_) ->
@@ -65,14 +65,14 @@
 
 'assoc'(Assoc, Key, Value) ->
   case Assoc of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'assoc'(Assoc, Key, Value);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'assoc'(Assoc, Key, Value);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'assoc'(Assoc, Key, Value);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'assoc'(Assoc, Key, Value);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'assoc'(Assoc, Key, Value);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'assoc'(Assoc, Key, Value);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'assoc', Assoc);
     X_ when erlang:is_binary(X_) ->
@@ -89,10 +89,10 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -103,10 +103,10 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.SortedMap' -> true;
     'clojerl.Map' -> true;
-    'clojerl.Vector' -> true;
+    'clojerl.SortedMap' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
     'erlang.Map' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IChunk.erl
+++ b/src/erl/lang/protocols/clojerl.IChunk.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'drop_first'(any()) -> any().
+-optional_callbacks(['drop_first'/1]).
 
 'drop_first'(Chunk) ->
   case Chunk of

--- a/src/erl/lang/protocols/clojerl.IChunkedSeq.erl
+++ b/src/erl/lang/protocols/clojerl.IChunkedSeq.erl
@@ -17,12 +17,12 @@
 
 'chunked_first'(Seq) ->
   case Seq of
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'chunked_first'(Seq);
     #{?TYPE := 'clojerl.Range'} ->
       'clojerl.Range':'chunked_first'(Seq);
     #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
       'clojerl.Vector.ChunkedSeq':'chunked_first'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'chunked_first'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'chunked_first', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -37,12 +37,12 @@
 
 'chunked_next'(Seq) ->
   case Seq of
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'chunked_next'(Seq);
     #{?TYPE := 'clojerl.Range'} ->
       'clojerl.Range':'chunked_next'(Seq);
     #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
       'clojerl.Vector.ChunkedSeq':'chunked_next'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'chunked_next'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'chunked_next', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -57,12 +57,12 @@
 
 'chunked_more'(Seq) ->
   case Seq of
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'chunked_more'(Seq);
     #{?TYPE := 'clojerl.Range'} ->
       'clojerl.Range':'chunked_more'(Seq);
     #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
       'clojerl.Vector.ChunkedSeq':'chunked_more'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'chunked_more'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'chunked_more', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -77,9 +77,9 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := 'clojerl.Range'} ->  true;
     #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -89,8 +89,8 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.ChunkedCons' -> true;
     'clojerl.Range' -> true;
     'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.ChunkedCons' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IChunkedSeq.erl
+++ b/src/erl/lang/protocols/clojerl.IChunkedSeq.erl
@@ -13,6 +13,7 @@
 -callback 'chunked_first'(any()) -> any().
 -callback 'chunked_next'(any()) -> any().
 -callback 'chunked_more'(any()) -> any().
+-optional_callbacks(['chunked_first'/1, 'chunked_next'/1, 'chunked_more'/1]).
 
 'chunked_first'(Seq) ->
   case Seq of

--- a/src/erl/lang/protocols/clojerl.IColl.erl
+++ b/src/erl/lang/protocols/clojerl.IColl.erl
@@ -12,6 +12,7 @@
 
 -callback 'cons'(any(), any()) -> any().
 -callback 'empty'(any()) -> any().
+-optional_callbacks(['cons'/2, 'empty'/1]).
 
 'cons'(Coll, Item) ->
   case Coll of

--- a/src/erl/lang/protocols/clojerl.IColl.erl
+++ b/src/erl/lang/protocols/clojerl.IColl.erl
@@ -16,40 +16,40 @@
 
 'cons'(Coll, Item) ->
   case Coll of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'cons'(Coll, Item);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'cons'(Coll, Item);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'cons'(Coll, Item);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'cons'(Coll, Item);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'cons'(Coll, Item);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'cons', Coll);
     X_ when erlang:is_binary(X_) ->
@@ -68,40 +68,40 @@
 
 'empty'(Coll) ->
   case Coll of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'empty'(Coll);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'empty'(Coll);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'empty'(Coll);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'empty'(Coll);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'empty'(Coll);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'empty'(Coll);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'empty'(Coll);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'empty'(Coll);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'empty'(Coll);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'empty'(Coll);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'empty'(Coll);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'empty'(Coll);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'empty'(Coll);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'empty'(Coll);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'empty'(Coll);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'empty'(Coll);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'empty'(Coll);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'empty'(Coll);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'empty'(Coll);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'empty'(Coll);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'empty'(Coll);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'empty'(Coll);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'empty'(Coll);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'empty'(Coll);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'empty'(Coll);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'empty'(Coll);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'empty'(Coll);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'empty'(Coll);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'empty'(Coll);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'empty'(Coll);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'empty'(Coll);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'empty'(Coll);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'empty', Coll);
     X_ when erlang:is_binary(X_) ->
@@ -120,23 +120,23 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -148,23 +148,23 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.StringSeq' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     'erlang.List' -> true;
     'erlang.Map' -> true;
     _ -> false

--- a/src/erl/lang/protocols/clojerl.ICounted.erl
+++ b/src/erl/lang/protocols/clojerl.ICounted.erl
@@ -15,44 +15,44 @@
 
 'count'(Seq) ->
   case Seq of
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'count'(Seq);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'count'(Seq);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'count'(Seq);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'count'(Seq);
     #{?TYPE := 'clojerl.Iterate'} ->
       'clojerl.Iterate':'count'(Seq);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'count'(Seq);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'count'(Seq);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'count'(Seq);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'count'(Seq);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'count'(Seq);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'count'(Seq);
     #{?TYPE := 'clojerl.LazySeq'} ->
       'clojerl.LazySeq':'count'(Seq);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'count'(Seq);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'count'(Seq);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'count'(Seq);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'count'(Seq);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'count'(Seq);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'count'(Seq);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'count'(Seq);
     #{?TYPE := 'clojerl.SortedSet'} ->
       'clojerl.SortedSet':'count'(Seq);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'count'(Seq);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'count'(Seq);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'count'(Seq);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'count'(Seq);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'count'(Seq);
     #{?TYPE := 'clojerl.Vector.RSeq'} ->
       'clojerl.Vector.RSeq':'count'(Seq);
     #{?TYPE := 'erlang.io.StringWriter'} ->
       'erlang.io.StringWriter':'count'(Seq);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'count'(Seq);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'count'(Seq);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'count'(Seq);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'count'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'count'(Seq);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'count'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'count', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -75,25 +75,25 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
     #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
     #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
     #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := 'erlang.io.StringWriter'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -107,25 +107,25 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.TupleChunk' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
     'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
     'clojerl.LazySeq' -> true;
-    'clojerl.Vector' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
     'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.TupleChunk' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
     'clojerl.Vector.RSeq' -> true;
     'erlang.io.StringWriter' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.StringSeq' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.TupleMap' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'erlang.List' -> true;

--- a/src/erl/lang/protocols/clojerl.ICounted.erl
+++ b/src/erl/lang/protocols/clojerl.ICounted.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'count'(any()) -> any().
+-optional_callbacks(['count'/1]).
 
 'count'(Seq) ->
   case Seq of

--- a/src/erl/lang/protocols/clojerl.IDeref.erl
+++ b/src/erl/lang/protocols/clojerl.IDeref.erl
@@ -15,16 +15,16 @@
 
 'deref'(Ref) ->
   case Ref of
-    #{?TYPE := 'clojerl.Reduced'} ->
-      'clojerl.Reduced':'deref'(Ref);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'deref'(Ref);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'deref'(Ref);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'deref'(Ref);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'deref'(Ref);
     #{?TYPE := 'clojerl.ProcessVal'} ->
       'clojerl.ProcessVal':'deref'(Ref);
+    #{?TYPE := 'clojerl.Reduced'} ->
+      'clojerl.Reduced':'deref'(Ref);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'deref'(Ref);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'deref', Ref);
     X_ when erlang:is_binary(X_) ->
@@ -39,11 +39,11 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Reduced'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'clojerl.Reduced'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -53,10 +53,10 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Reduced' -> true;
-    'clojerl.Delay' -> true;
     'clojerl.Atom' -> true;
-    'clojerl.Var' -> true;
+    'clojerl.Delay' -> true;
     'clojerl.ProcessVal' -> true;
+    'clojerl.Reduced' -> true;
+    'clojerl.Var' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IDeref.erl
+++ b/src/erl/lang/protocols/clojerl.IDeref.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'deref'(any()) -> any().
+-optional_callbacks(['deref'/1]).
 
 'deref'(Ref) ->
   case Ref of

--- a/src/erl/lang/protocols/clojerl.IEquiv.erl
+++ b/src/erl/lang/protocols/clojerl.IEquiv.erl
@@ -15,74 +15,74 @@
 
 'equiv'(X, Y) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'equiv'(X, Y);
     #{?TYPE := 'clojerl.AssertionError'} ->
       'clojerl.AssertionError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'equiv'(X, Y);
     #{?TYPE := 'clojerl.Cons'} ->
       'clojerl.Cons':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'equiv'(X, Y);
     #{?TYPE := 'clojerl.Error'} ->
       'clojerl.Error':'equiv'(X, Y);
     #{?TYPE := 'clojerl.ExceptionInfo'} ->
       'clojerl.ExceptionInfo':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'equiv'(X, Y);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.IOError'} ->
+      'clojerl.IOError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'equiv'(X, Y);
     #{?TYPE := 'clojerl.LazySeq'} ->
       'clojerl.LazySeq':'equiv'(X, Y);
     #{?TYPE := 'clojerl.List'} ->
       'clojerl.List':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.IOError'} ->
-      'clojerl.IOError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'equiv'(X, Y);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'equiv'(X, Y);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'equiv', X);
     X_ when erlang:is_binary(X_) ->
@@ -103,40 +103,40 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Error'} ->  true;
     #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.IOError'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
     #{?TYPE := 'clojerl.LazySeq'} ->  true;
     #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.IOError'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -149,40 +149,40 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Map' -> true;
-    'clojerl.TupleChunk' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.StringSeq' -> true;
+    'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.ProcessVal' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Symbol' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.ChunkedCons' -> true;
     'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Delay' -> true;
     'clojerl.Error' -> true;
     'clojerl.ExceptionInfo' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.reader.TaggedLiteral' -> true;
-    'clojerl.ArityError' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.Delay' -> true;
-    'clojerl.Range' -> true;
+    'clojerl.IOError' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Iterate' -> true;
     'clojerl.LazySeq' -> true;
     'clojerl.List' -> true;
-    'clojerl.IOError' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.ProcessVal' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.TupleChunk' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'clojerl.reader.TaggedLiteral' -> true;
+    'erlang.util.Date' -> true;
     'erlang.List' -> true;
     'erlang.Map' -> true;
     'erlang.Tuple' -> true;

--- a/src/erl/lang/protocols/clojerl.IEquiv.erl
+++ b/src/erl/lang/protocols/clojerl.IEquiv.erl
@@ -11,77 +11,78 @@
 -export([?EXTENDS/1]).
 
 -callback 'equiv'(any(), any()) -> any().
+-optional_callbacks(['equiv'/2]).
 
 'equiv'(X, Y) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->
-      'clojerl.IOError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'equiv'(X, Y);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->
-      'clojerl.ExceptionInfo':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Error'} ->
-      'clojerl.Error':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.AssertionError'} ->
-      'clojerl.AssertionError':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'equiv'(X, Y);
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'equiv'(X, Y);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.AssertionError'} ->
+      'clojerl.AssertionError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Error'} ->
+      'clojerl.Error':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->
+      'clojerl.ExceptionInfo':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'equiv'(X, Y);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'equiv'(X, Y);
+    #{?TYPE := 'clojerl.IOError'} ->
+      'clojerl.IOError':'equiv'(X, Y);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'equiv', X);
     X_ when erlang:is_binary(X_) ->
@@ -102,40 +103,40 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'clojerl.Error'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.AssertionError'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Error'} ->  true;
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.IOError'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -148,40 +149,40 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.IOError' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.Delay' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.ArityError' -> true;
-    'clojerl.reader.TaggedLiteral' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.ExceptionInfo' -> true;
-    'clojerl.Error' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.Symbol' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.ProcessVal' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.AssertionError' -> true;
-    'clojerl.StringSeq' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.TupleChunk' -> true;
     'clojerl.Map' -> true;
+    'clojerl.TupleChunk' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.AssertionError' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.ProcessVal' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Error' -> true;
+    'clojerl.ExceptionInfo' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.reader.TaggedLiteral' -> true;
+    'clojerl.ArityError' -> true;
+    'erlang.util.Date' -> true;
+    'clojerl.Delay' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.IOError' -> true;
     'erlang.List' -> true;
     'erlang.Map' -> true;
     'erlang.Tuple' -> true;

--- a/src/erl/lang/protocols/clojerl.IErl.erl
+++ b/src/erl/lang/protocols/clojerl.IErl.erl
@@ -15,26 +15,26 @@
 
 '->erl'(X, Recursive) ->
   case X of
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'->erl'(X, Recursive);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'->erl'(X, Recursive);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'->erl'(X, Recursive);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'->erl'(X, Recursive);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'->erl'(X, Recursive);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, '->erl', X);
     X_ when erlang:is_binary(X_) ->
@@ -49,16 +49,16 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -68,15 +68,15 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Range' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Range' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IErl.erl
+++ b/src/erl/lang/protocols/clojerl.IErl.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback '->erl'(any(), any()) -> any().
+-optional_callbacks(['->erl'/2]).
 
 '->erl'(X, Recursive) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IError.erl
+++ b/src/erl/lang/protocols/clojerl.IError.erl
@@ -15,20 +15,20 @@
 
 'message'(Error) ->
   case Error of
-    #{?TYPE := 'clojerl.IOError'} ->
-      'clojerl.IOError':'message'(Error);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'message'(Error);
+    #{?TYPE := 'clojerl.AssertionError'} ->
+      'clojerl.AssertionError':'message'(Error);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'message'(Error);
     #{?TYPE := 'clojerl.Error'} ->
       'clojerl.Error':'message'(Error);
     #{?TYPE := 'clojerl.ExceptionInfo'} ->
       'clojerl.ExceptionInfo':'message'(Error);
+    #{?TYPE := 'clojerl.IOError'} ->
+      'clojerl.IOError':'message'(Error);
     #{?TYPE := 'clojerl.IllegalAccessError'} ->
       'clojerl.IllegalAccessError':'message'(Error);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'message'(Error);
-    #{?TYPE := 'clojerl.AssertionError'} ->
-      'clojerl.AssertionError':'message'(Error);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'message'(Error);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'message', Error);
     X_ when erlang:is_binary(X_) ->
@@ -43,13 +43,13 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
+    #{?TYPE := 'clojerl.AssertionError'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
     #{?TYPE := 'clojerl.Error'} ->  true;
     #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
+    #{?TYPE := 'clojerl.IOError'} ->  true;
     #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -59,12 +59,12 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.IOError' -> true;
+    'clojerl.ArityError' -> true;
+    'clojerl.AssertionError' -> true;
+    'clojerl.BadArgumentError' -> true;
     'clojerl.Error' -> true;
     'clojerl.ExceptionInfo' -> true;
+    'clojerl.IOError' -> true;
     'clojerl.IllegalAccessError' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.AssertionError' -> true;
-    'clojerl.ArityError' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IError.erl
+++ b/src/erl/lang/protocols/clojerl.IError.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'message'(any()) -> any().
+-optional_callbacks(['message'/1]).
 
 'message'(Error) ->
   case Error of

--- a/src/erl/lang/protocols/clojerl.IExceptionInfo.erl
+++ b/src/erl/lang/protocols/clojerl.IExceptionInfo.erl
@@ -12,6 +12,7 @@
 
 -callback 'data'(any()) -> any().
 -callback 'cause'(any()) -> any().
+-optional_callbacks(['data'/1, 'cause'/1]).
 
 'data'(ExInfo) ->
   case ExInfo of

--- a/src/erl/lang/protocols/clojerl.IFn.erl
+++ b/src/erl/lang/protocols/clojerl.IFn.erl
@@ -15,24 +15,24 @@
 
 'apply'(Fn, Args) ->
   case Fn of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'apply'(Fn, Args);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'apply'(Fn, Args);
     #{?TYPE := 'clojerl.Fn'} ->
       'clojerl.Fn':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'apply'(Fn, Args);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'apply'(Fn, Args);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'apply'(Fn, Args);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'apply', Fn);
     X_ when erlang:is_binary(X_) ->
@@ -53,15 +53,15 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
     #{?TYPE := 'clojerl.Fn'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -74,15 +74,15 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.Symbol' -> true;
     'clojerl.Fn' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.Symbol' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.Vector' -> true;
     'erlang.Map' -> true;
     'erlang.Fn' -> true;
     'clojerl.Keyword' -> true;

--- a/src/erl/lang/protocols/clojerl.IFn.erl
+++ b/src/erl/lang/protocols/clojerl.IFn.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'apply'(any(), any()) -> any().
+-optional_callbacks(['apply'/2]).
 
 'apply'(Fn, Args) ->
   case Fn of

--- a/src/erl/lang/protocols/clojerl.IHash.erl
+++ b/src/erl/lang/protocols/clojerl.IHash.erl
@@ -15,82 +15,82 @@
 
 'hash'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'hash'(X);
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'hash'(X);
-    #{?TYPE := 'erlang.Type'} ->
-      'erlang.Type':'hash'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'hash'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'hash'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'hash'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'hash'(X);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'hash'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'hash'(X);
-    #{?TYPE := 'erlang.util.UUID'} ->
-      'erlang.util.UUID':'hash'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'hash'(X);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'hash'(X);
     #{?TYPE := 'clojerl.AssertionError'} ->
       'clojerl.AssertionError':'hash'(X);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'hash'(X);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'hash'(X);
-    #{?TYPE := 'erlang.util.Regex'} ->
-      'erlang.util.Regex':'hash'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'hash'(X);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'hash'(X);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'hash'(X);
-    #{?TYPE := 'clojerl.Reduced'} ->
-      'clojerl.Reduced':'hash'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'hash'(X);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'hash'(X);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'hash'(X);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'hash'(X);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'hash'(X);
     #{?TYPE := 'clojerl.Cons'} ->
       'clojerl.Cons':'hash'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'hash'(X);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'hash'(X);
     #{?TYPE := 'clojerl.Error'} ->
       'clojerl.Error':'hash'(X);
     #{?TYPE := 'clojerl.ExceptionInfo'} ->
       'clojerl.ExceptionInfo':'hash'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'hash'(X);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'hash'(X);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'hash'(X);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'hash'(X);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'hash'(X);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'hash'(X);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'hash'(X);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'hash'(X);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'hash'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'hash'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'hash'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'hash'(X);
     #{?TYPE := 'clojerl.Fn'} ->
       'clojerl.Fn':'hash'(X);
     #{?TYPE := 'clojerl.IOError'} ->
       'clojerl.IOError':'hash'(X);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'hash'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'hash'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'hash'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'hash'(X);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'hash'(X);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'hash'(X);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'hash'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'hash'(X);
+    #{?TYPE := 'clojerl.Reduced'} ->
+      'clojerl.Reduced':'hash'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'hash'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'hash'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'hash'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'hash'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'hash'(X);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'hash'(X);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'hash'(X);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'hash'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'hash'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'hash'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'hash'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'hash'(X);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'hash'(X);
+    #{?TYPE := 'erlang.Type'} ->
+      'erlang.Type':'hash'(X);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'hash'(X);
+    #{?TYPE := 'erlang.util.Regex'} ->
+      'erlang.util.Regex':'hash'(X);
+    #{?TYPE := 'erlang.util.UUID'} ->
+      'erlang.util.UUID':'hash'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'hash', X);
     X_ when erlang:is_binary(X_) ->
@@ -127,44 +127,44 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
-    #{?TYPE := 'erlang.Type'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'erlang.util.UUID'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'erlang.util.Regex'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Reduced'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Error'} ->  true;
     #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.Namespace'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
     #{?TYPE := 'clojerl.Fn'} ->  true;
     #{?TYPE := 'clojerl.IOError'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Namespace'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Reduced'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'erlang.Type'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
+    #{?TYPE := 'erlang.util.Regex'} ->  true;
+    #{?TYPE := 'erlang.util.UUID'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -185,44 +185,44 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Map' -> true;
-    'clojerl.TupleChunk' -> true;
-    'erlang.Type' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Repeat' -> true;
-    'erlang.util.UUID' -> true;
-    'clojerl.StringSeq' -> true;
+    'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.ProcessVal' -> true;
-    'erlang.util.Regex' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Reduced' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Symbol' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.ChunkedCons' -> true;
     'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Delay' -> true;
     'clojerl.Error' -> true;
     'clojerl.ExceptionInfo' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.Namespace' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.ArityError' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.Delay' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.List' -> true;
     'clojerl.Fn' -> true;
     'clojerl.IOError' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Namespace' -> true;
+    'clojerl.ProcessVal' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Reduced' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.TupleChunk' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'erlang.Type' -> true;
+    'erlang.util.Date' -> true;
+    'erlang.util.Regex' -> true;
+    'erlang.util.UUID' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'clojerl.Integer' -> true;

--- a/src/erl/lang/protocols/clojerl.IHash.erl
+++ b/src/erl/lang/protocols/clojerl.IHash.erl
@@ -11,85 +11,86 @@
 -export([?EXTENDS/1]).
 
 -callback 'hash'(any()) -> any().
+-optional_callbacks(['hash'/1]).
 
 'hash'(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->
-      'clojerl.IOError':'hash'(X);
-    #{?TYPE := 'clojerl.Fn'} ->
-      'clojerl.Fn':'hash'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'hash'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'hash'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'hash'(X);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'hash'(X);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'hash'(X);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'hash'(X);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'hash'(X);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'hash'(X);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'hash'(X);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'hash'(X);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'hash'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'hash'(X);
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->
-      'clojerl.ExceptionInfo':'hash'(X);
-    #{?TYPE := 'clojerl.Error'} ->
-      'clojerl.Error':'hash'(X);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'hash'(X);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'hash'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'hash'(X);
-    #{?TYPE := 'clojerl.Reduced'} ->
-      'clojerl.Reduced':'hash'(X);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'hash'(X);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'hash'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'hash'(X);
-    #{?TYPE := 'erlang.util.Regex'} ->
-      'erlang.util.Regex':'hash'(X);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'hash'(X);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'hash'(X);
-    #{?TYPE := 'clojerl.AssertionError'} ->
-      'clojerl.AssertionError':'hash'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'hash'(X);
-    #{?TYPE := 'erlang.util.UUID'} ->
-      'erlang.util.UUID':'hash'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'hash'(X);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'hash'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'hash'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'hash'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'hash'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'hash'(X);
-    #{?TYPE := 'erlang.Type'} ->
-      'erlang.Type':'hash'(X);
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'hash'(X);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'hash'(X);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'hash'(X);
+    #{?TYPE := 'erlang.Type'} ->
+      'erlang.Type':'hash'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'hash'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'hash'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'hash'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'hash'(X);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'hash'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'hash'(X);
+    #{?TYPE := 'erlang.util.UUID'} ->
+      'erlang.util.UUID':'hash'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'hash'(X);
+    #{?TYPE := 'clojerl.AssertionError'} ->
+      'clojerl.AssertionError':'hash'(X);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'hash'(X);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'hash'(X);
+    #{?TYPE := 'erlang.util.Regex'} ->
+      'erlang.util.Regex':'hash'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'hash'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'hash'(X);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'hash'(X);
+    #{?TYPE := 'clojerl.Reduced'} ->
+      'clojerl.Reduced':'hash'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'hash'(X);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'hash'(X);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'hash'(X);
+    #{?TYPE := 'clojerl.Error'} ->
+      'clojerl.Error':'hash'(X);
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->
+      'clojerl.ExceptionInfo':'hash'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'hash'(X);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'hash'(X);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'hash'(X);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'hash'(X);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'hash'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'hash'(X);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'hash'(X);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'hash'(X);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'hash'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'hash'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'hash'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'hash'(X);
+    #{?TYPE := 'clojerl.Fn'} ->
+      'clojerl.Fn':'hash'(X);
+    #{?TYPE := 'clojerl.IOError'} ->
+      'clojerl.IOError':'hash'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'hash', X);
     X_ when erlang:is_binary(X_) ->
@@ -126,44 +127,44 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->  true;
-    #{?TYPE := 'clojerl.Fn'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.Namespace'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'clojerl.Error'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Reduced'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'erlang.util.Regex'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'erlang.util.UUID'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'erlang.Type'} ->  true;
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'erlang.Type'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'erlang.util.UUID'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.AssertionError'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'erlang.util.Regex'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Reduced'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Error'} ->  true;
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.Namespace'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Fn'} ->  true;
+    #{?TYPE := 'clojerl.IOError'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -184,44 +185,44 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.IOError' -> true;
-    'clojerl.Fn' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.Delay' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.ArityError' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.Namespace' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.ExceptionInfo' -> true;
-    'clojerl.Error' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.Symbol' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Reduced' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'erlang.util.Regex' -> true;
-    'clojerl.ProcessVal' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.AssertionError' -> true;
-    'clojerl.StringSeq' -> true;
-    'erlang.util.UUID' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.SortedSet' -> true;
-    'erlang.Type' -> true;
-    'clojerl.TupleChunk' -> true;
     'clojerl.Map' -> true;
+    'clojerl.TupleChunk' -> true;
+    'erlang.Type' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.Repeat' -> true;
+    'erlang.util.UUID' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.AssertionError' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.ProcessVal' -> true;
+    'erlang.util.Regex' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Reduced' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Error' -> true;
+    'clojerl.ExceptionInfo' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.Namespace' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.ArityError' -> true;
+    'erlang.util.Date' -> true;
+    'clojerl.Delay' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Fn' -> true;
+    'clojerl.IOError' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'clojerl.Integer' -> true;

--- a/src/erl/lang/protocols/clojerl.IIndexed.erl
+++ b/src/erl/lang/protocols/clojerl.IIndexed.erl
@@ -12,6 +12,7 @@
 
 -callback 'nth'(any(), any()) -> any().
 -callback 'nth'(any(), any(), any()) -> any().
+-optional_callbacks(['nth'/2, 'nth'/3]).
 
 'nth'(Coll, N) ->
   case Coll of

--- a/src/erl/lang/protocols/clojerl.ILookup.erl
+++ b/src/erl/lang/protocols/clojerl.ILookup.erl
@@ -16,22 +16,22 @@
 
 'get'(X, Key) ->
   case X of
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'get'(X, Key);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'get'(X, Key);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'get'(X, Key);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'get'(X, Key);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'get'(X, Key);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'get'(X, Key);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'get'(X, Key);
     #{?TYPE := 'clojerl.SortedSet'} ->
       'clojerl.SortedSet':'get'(X, Key);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'get'(X, Key);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'get'(X, Key);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'get'(X, Key);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'get'(X, Key);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'get'(X, Key);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'get', X);
     X_ when erlang:is_binary(X_) ->
@@ -50,22 +50,22 @@
 
 'get'(X, Key, NotFound) ->
   case X of
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'get'(X, Key, NotFound);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'get'(X, Key, NotFound);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'get'(X, Key, NotFound);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'get'(X, Key, NotFound);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'get'(X, Key, NotFound);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'get'(X, Key, NotFound);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'get'(X, Key, NotFound);
     #{?TYPE := 'clojerl.SortedSet'} ->
       'clojerl.SortedSet':'get'(X, Key, NotFound);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'get'(X, Key, NotFound);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'get'(X, Key, NotFound);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'get'(X, Key, NotFound);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'get'(X, Key, NotFound);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'get'(X, Key, NotFound);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'get', X);
     X_ when erlang:is_binary(X_) ->
@@ -84,14 +84,14 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -103,14 +103,14 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
     'clojerl.Map' -> true;
-    'clojerl.Vector' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
     'clojerl.SortedSet' -> true;
-    'clojerl.reader.TaggedLiteral' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'clojerl.reader.TaggedLiteral' -> true;
     'erlang.List' -> true;
     'erlang.Map' -> true;
     _ -> false

--- a/src/erl/lang/protocols/clojerl.ILookup.erl
+++ b/src/erl/lang/protocols/clojerl.ILookup.erl
@@ -12,6 +12,7 @@
 
 -callback 'get'(any(), any()) -> any().
 -callback 'get'(any(), any(), any()) -> any().
+-optional_callbacks(['get'/2, 'get'/3]).
 
 'get'(X, Key) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IMap.erl
+++ b/src/erl/lang/protocols/clojerl.IMap.erl
@@ -13,6 +13,7 @@
 -callback 'keys'(any()) -> any().
 -callback 'vals'(any()) -> any().
 -callback 'without'(any(), any()) -> any().
+-optional_callbacks(['keys'/1, 'vals'/1, 'without'/2]).
 
 'keys'(Map) ->
   case Map of

--- a/src/erl/lang/protocols/clojerl.IMap.erl
+++ b/src/erl/lang/protocols/clojerl.IMap.erl
@@ -17,10 +17,10 @@
 
 'keys'(Map) ->
   case Map of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'keys'(Map);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'keys'(Map);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'keys'(Map);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'keys'(Map);
     #{?TYPE := _} ->
@@ -39,10 +39,10 @@
 
 'vals'(Map) ->
   case Map of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'vals'(Map);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'vals'(Map);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'vals'(Map);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'vals'(Map);
     #{?TYPE := _} ->
@@ -61,10 +61,10 @@
 
 'without'(Map, Key) ->
   case Map of
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'without'(Map, Key);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'without'(Map, Key);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'without'(Map, Key);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'without'(Map, Key);
     #{?TYPE := _} ->
@@ -83,8 +83,8 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
@@ -96,8 +96,8 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.SortedMap' -> true;
     'clojerl.Map' -> true;
+    'clojerl.SortedMap' -> true;
     'clojerl.TupleMap' -> true;
     'erlang.Map' -> true;
     _ -> false

--- a/src/erl/lang/protocols/clojerl.IMeta.erl
+++ b/src/erl/lang/protocols/clojerl.IMeta.erl
@@ -12,6 +12,7 @@
 
 -callback 'meta'(any()) -> any().
 -callback 'with_meta'(any(), any()) -> any().
+-optional_callbacks(['meta'/1, 'with_meta'/2]).
 
 'meta'(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IMeta.erl
+++ b/src/erl/lang/protocols/clojerl.IMeta.erl
@@ -16,46 +16,46 @@
 
 'meta'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'meta'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'meta'(X);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'meta'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'meta'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'meta'(X);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'meta'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'meta'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'meta'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'meta'(X);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'meta'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'meta'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'meta'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'meta'(X);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'meta'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'meta'(X);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'meta'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'meta'(X);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'meta'(X);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'meta'(X);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'meta'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'meta'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'meta'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'meta'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'meta'(X);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'meta'(X);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'meta'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'meta'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'meta'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'meta'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'meta'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'meta'(X);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'meta'(X);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'meta'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'meta'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'meta'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'meta'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'meta'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'meta', X);
     X_ when erlang:is_binary(X_) ->
@@ -70,46 +70,46 @@
 
 'with_meta'(X, Meta) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'with_meta'(X, Meta);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'with_meta'(X, Meta);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'with_meta'(X, Meta);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'with_meta'(X, Meta);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'with_meta'(X, Meta);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'with_meta'(X, Meta);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'with_meta', X);
     X_ when erlang:is_binary(X_) ->
@@ -124,26 +124,26 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Namespace'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Namespace'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -153,25 +153,25 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
     'clojerl.Atom' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Namespace' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Symbol' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Namespace' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.Symbol' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.INamed.erl
+++ b/src/erl/lang/protocols/clojerl.INamed.erl
@@ -16,10 +16,10 @@
 
 'name'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'name'(X);
     #{?TYPE := 'clojerl.Symbol'} ->
       'clojerl.Symbol':'name'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'name'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'name', X);
     X_ when erlang:is_binary(X_) ->
@@ -36,10 +36,10 @@
 
 'namespace'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'namespace'(X);
     #{?TYPE := 'clojerl.Symbol'} ->
       'clojerl.Symbol':'namespace'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'namespace'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'namespace', X);
     X_ when erlang:is_binary(X_) ->
@@ -56,8 +56,8 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Var'} ->  true;
     #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -68,8 +68,8 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Var' -> true;
     'clojerl.Symbol' -> true;
+    'clojerl.Var' -> true;
     'clojerl.Keyword' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.INamed.erl
+++ b/src/erl/lang/protocols/clojerl.INamed.erl
@@ -12,6 +12,7 @@
 
 -callback 'name'(any()) -> any().
 -callback 'namespace'(any()) -> any().
+-optional_callbacks(['name'/1, 'namespace'/1]).
 
 'name'(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IRecord.erl
+++ b/src/erl/lang/protocols/clojerl.IRecord.erl
@@ -10,6 +10,7 @@
 -export([?EXTENDS/1]).
 
 -callback '_'(any()) -> any().
+-optional_callbacks(['_'/1]).
 
 ?SATISFIES(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IReduce.erl
+++ b/src/erl/lang/protocols/clojerl.IReduce.erl
@@ -16,28 +16,28 @@
 
 'reduce'(Coll, Fun) ->
   case Coll of
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'reduce'(Coll, Fun);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'reduce'(Coll, Fun);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'reduce'(Coll, Fun);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'reduce', Coll);
     X_ when erlang:is_binary(X_) ->
@@ -54,28 +54,28 @@
 
 'reduce'(Coll, Fun, Init) ->
   case Coll of
-    #{?TYPE := 'clojerl.TupleChunk'} ->
-      'clojerl.TupleChunk':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'reduce'(Coll, Fun, Init);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.TupleChunk'} ->
+      'clojerl.TupleChunk':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'reduce'(Coll, Fun, Init);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'reduce'(Coll, Fun, Init);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'reduce', Coll);
     X_ when erlang:is_binary(X_) ->
@@ -92,17 +92,17 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.TupleChunk'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -113,17 +113,17 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.TupleChunk' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.TupleChunk' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
     'erlang.List' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IReduce.erl
+++ b/src/erl/lang/protocols/clojerl.IReduce.erl
@@ -12,6 +12,7 @@
 
 -callback 'reduce'(any(), any()) -> any().
 -callback 'reduce'(any(), any(), any()) -> any().
+-optional_callbacks(['reduce'/2, 'reduce'/3]).
 
 'reduce'(Coll, Fun) ->
   case Coll of

--- a/src/erl/lang/protocols/clojerl.IReference.erl
+++ b/src/erl/lang/protocols/clojerl.IReference.erl
@@ -12,6 +12,7 @@
 
 -callback 'alter_meta'(any(), any(), any()) -> any().
 -callback 'reset_meta'(any(), any()) -> any().
+-optional_callbacks(['alter_meta'/3, 'reset_meta'/2]).
 
 'alter_meta'(Ref, Fun, Args) ->
   case Ref of

--- a/src/erl/lang/protocols/clojerl.IReversible.erl
+++ b/src/erl/lang/protocols/clojerl.IReversible.erl
@@ -11,6 +11,7 @@
 -export([?EXTENDS/1]).
 
 -callback 'rseq'(any()) -> any().
+-optional_callbacks(['rseq'/1]).
 
 'rseq'(Seq) ->
   case Seq of

--- a/src/erl/lang/protocols/clojerl.ISeq.erl
+++ b/src/erl/lang/protocols/clojerl.ISeq.erl
@@ -13,6 +13,7 @@
 -callback 'first'(any()) -> any().
 -callback 'next'(any()) -> any().
 -callback 'more'(any()) -> any().
+-optional_callbacks(['first'/1, 'next'/1, 'more'/1]).
 
 'first'(Seq) ->
   case Seq of

--- a/src/erl/lang/protocols/clojerl.ISeq.erl
+++ b/src/erl/lang/protocols/clojerl.ISeq.erl
@@ -17,30 +17,30 @@
 
 'first'(Seq) ->
   case Seq of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'first'(Seq);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'first'(Seq);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'first'(Seq);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'first'(Seq);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'first'(Seq);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'first'(Seq);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'first'(Seq);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'first'(Seq);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'first'(Seq);
     #{?TYPE := 'clojerl.Cycle'} ->
       'clojerl.Cycle':'first'(Seq);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'first'(Seq);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'first'(Seq);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'first'(Seq);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'first'(Seq);
     #{?TYPE := 'clojerl.Repeat'} ->
       'clojerl.Repeat':'first'(Seq);
     #{?TYPE := 'clojerl.StringSeq'} ->
       'clojerl.StringSeq':'first'(Seq);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'first'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'first'(Seq);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'first'(Seq);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'first'(Seq);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'first'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'first', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -57,30 +57,30 @@
 
 'next'(Seq) ->
   case Seq of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'next'(Seq);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'next'(Seq);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'next'(Seq);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'next'(Seq);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'next'(Seq);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'next'(Seq);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'next'(Seq);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'next'(Seq);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'next'(Seq);
     #{?TYPE := 'clojerl.Cycle'} ->
       'clojerl.Cycle':'next'(Seq);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'next'(Seq);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'next'(Seq);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'next'(Seq);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'next'(Seq);
     #{?TYPE := 'clojerl.Repeat'} ->
       'clojerl.Repeat':'next'(Seq);
     #{?TYPE := 'clojerl.StringSeq'} ->
       'clojerl.StringSeq':'next'(Seq);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'next'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'next'(Seq);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'next'(Seq);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'next'(Seq);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'next'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'next', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -97,30 +97,30 @@
 
 'more'(Seq) ->
   case Seq of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'more'(Seq);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'more'(Seq);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'more'(Seq);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'more'(Seq);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'more'(Seq);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'more'(Seq);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'more'(Seq);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'more'(Seq);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'more'(Seq);
     #{?TYPE := 'clojerl.Cycle'} ->
       'clojerl.Cycle':'more'(Seq);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'more'(Seq);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'more'(Seq);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'more'(Seq);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'more'(Seq);
     #{?TYPE := 'clojerl.Repeat'} ->
       'clojerl.Repeat':'more'(Seq);
     #{?TYPE := 'clojerl.StringSeq'} ->
       'clojerl.StringSeq':'more'(Seq);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'more'(Seq);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'more'(Seq);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'more'(Seq);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'more'(Seq);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'more'(Seq);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'more', Seq);
     X_ when erlang:is_binary(X_) ->
@@ -137,18 +137,18 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
     #{?TYPE := 'clojerl.Repeat'} ->  true;
     #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_boolean(X_) ->  false;
@@ -159,18 +159,18 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Vector.RSeq' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
     'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Range' -> true;
     'clojerl.Repeat' -> true;
     'clojerl.StringSeq' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.ChunkedCons' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     'erlang.List' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.ISeqable.erl
+++ b/src/erl/lang/protocols/clojerl.ISeqable.erl
@@ -16,42 +16,42 @@
 
 'seq'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'seq'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'seq'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'seq'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'seq'(X);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'seq'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'seq'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'seq'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'seq'(X);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'seq'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'seq'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'seq'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'seq'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'seq'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'seq'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'seq'(X);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'seq'(X);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'seq'(X);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'seq'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'seq'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'seq'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'seq'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'seq'(X);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'seq'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'seq'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'seq'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'seq'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'seq'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'seq'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'seq'(X);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'seq'(X);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'seq'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'seq'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'seq'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'seq'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'seq', X);
     X_ when erlang:is_binary(X_) ->
@@ -74,42 +74,42 @@
 
 'to_list'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'to_list'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'to_list'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'to_list'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'to_list'(X);
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'to_list'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'to_list'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'to_list'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'to_list'(X);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'to_list'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'to_list'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'to_list'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'to_list'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'to_list'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'to_list'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'to_list'(X);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'to_list'(X);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'to_list'(X);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'to_list'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'to_list'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'to_list'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'to_list'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'to_list'(X);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'to_list'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'to_list'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'to_list'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'to_list'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'to_list'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'to_list'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'to_list'(X);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'to_list'(X);
     #{?TYPE := 'clojerl.TupleMap'} ->
       'clojerl.TupleMap':'to_list'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'to_list'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'to_list'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'to_list'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'to_list', X);
     X_ when erlang:is_binary(X_) ->
@@ -132,24 +132,24 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
     #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -163,24 +163,24 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.Map' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.StringSeq' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.TransducerSeq' -> true;
     'clojerl.TupleMap' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'erlang.List' -> true;

--- a/src/erl/lang/protocols/clojerl.ISeqable.erl
+++ b/src/erl/lang/protocols/clojerl.ISeqable.erl
@@ -12,6 +12,7 @@
 
 -callback 'seq'(any()) -> any().
 -callback 'to_list'(any()) -> any().
+-optional_callbacks(['seq'/1, 'to_list'/1]).
 
 'seq'(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.ISequential.erl
+++ b/src/erl/lang/protocols/clojerl.ISequential.erl
@@ -10,6 +10,7 @@
 -export([?EXTENDS/1]).
 
 -callback '_'(any()) -> any().
+-optional_callbacks(['_'/1]).
 
 ?SATISFIES(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.ISequential.erl
+++ b/src/erl/lang/protocols/clojerl.ISequential.erl
@@ -14,19 +14,19 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
     #{?TYPE := 'clojerl.Repeat'} ->  true;
     #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -39,19 +39,19 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Iterate' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Vector.RSeq' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Cons' -> true;
     'clojerl.Cycle' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Range' -> true;
     'clojerl.Repeat' -> true;
     'clojerl.StringSeq' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.ChunkedCons' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
     'clojerl.BitString' -> true;
     'erlang.List' -> true;
     'erlang.Tuple' -> true;

--- a/src/erl/lang/protocols/clojerl.ISet.erl
+++ b/src/erl/lang/protocols/clojerl.ISet.erl
@@ -12,6 +12,7 @@
 
 -callback 'disjoin'(any(), any()) -> any().
 -callback 'contains'(any(), any()) -> any().
+-optional_callbacks(['disjoin'/2, 'contains'/2]).
 
 'disjoin'(Coll, Item) ->
   case Coll of

--- a/src/erl/lang/protocols/clojerl.ISorted.erl
+++ b/src/erl/lang/protocols/clojerl.ISorted.erl
@@ -10,6 +10,7 @@
 -export([?EXTENDS/1]).
 
 -callback '_'(any()) -> any().
+-optional_callbacks(['_'/1]).
 
 ?SATISFIES(X) ->
   case X of

--- a/src/erl/lang/protocols/clojerl.IStack.erl
+++ b/src/erl/lang/protocols/clojerl.IStack.erl
@@ -12,6 +12,7 @@
 
 -callback 'peek'(any()) -> any().
 -callback 'pop'(any()) -> any().
+-optional_callbacks(['peek'/1, 'pop'/1]).
 
 'peek'(Stack) ->
   case Stack of

--- a/src/erl/lang/protocols/clojerl.IStringable.erl
+++ b/src/erl/lang/protocols/clojerl.IStringable.erl
@@ -11,95 +11,96 @@
 -export([?EXTENDS/1]).
 
 -callback 'str'(any()) -> any().
+-optional_callbacks(['str'/1]).
 
 'str'(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->
-      'clojerl.IOError':'str'(X);
-    #{?TYPE := 'clojerl.Fn'} ->
-      'clojerl.Fn':'str'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'str'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'str'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'str'(X);
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'str'(X);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'str'(X);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'str'(X);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'str'(X);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'str'(X);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'str'(X);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'str'(X);
-    #{?TYPE := 'erlang.io.StringReader'} ->
-      'erlang.io.StringReader':'str'(X);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'str'(X);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'str'(X);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'str'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'str'(X);
-    #{?TYPE := 'erlang.io.StringWriter'} ->
-      'erlang.io.StringWriter':'str'(X);
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->
-      'clojerl.ExceptionInfo':'str'(X);
-    #{?TYPE := 'clojerl.Error'} ->
-      'clojerl.Error':'str'(X);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'str'(X);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'str'(X);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'str'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'str'(X);
-    #{?TYPE := 'clojerl.Reduced'} ->
-      'clojerl.Reduced':'str'(X);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'str'(X);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'str'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'str'(X);
-    #{?TYPE := 'erlang.util.Regex'} ->
-      'erlang.util.Regex':'str'(X);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'str'(X);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'str'(X);
-    #{?TYPE := 'clojerl.AssertionError'} ->
-      'clojerl.AssertionError':'str'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'str'(X);
-    #{?TYPE := 'erlang.util.UUID'} ->
-      'erlang.util.UUID':'str'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'str'(X);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'str'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'str'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'str'(X);
-    #{?TYPE := 'erlang.io.File'} ->
-      'erlang.io.File':'str'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'str'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'str'(X);
-    #{?TYPE := 'erlang.Type'} ->
-      'erlang.Type':'str'(X);
     #{?TYPE := 'clojerl.Map'} ->
       'clojerl.Map':'str'(X);
+    #{?TYPE := 'erlang.Type'} ->
+      'erlang.Type':'str'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'str'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'str'(X);
+    #{?TYPE := 'erlang.io.File'} ->
+      'erlang.io.File':'str'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'str'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'str'(X);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'str'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'str'(X);
+    #{?TYPE := 'erlang.util.UUID'} ->
+      'erlang.util.UUID':'str'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'str'(X);
+    #{?TYPE := 'clojerl.AssertionError'} ->
+      'clojerl.AssertionError':'str'(X);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'str'(X);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'str'(X);
+    #{?TYPE := 'erlang.util.Regex'} ->
+      'erlang.util.Regex':'str'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'str'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'str'(X);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'str'(X);
+    #{?TYPE := 'clojerl.Reduced'} ->
+      'clojerl.Reduced':'str'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'str'(X);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'str'(X);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'str'(X);
+    #{?TYPE := 'clojerl.Cons'} ->
+      'clojerl.Cons':'str'(X);
+    #{?TYPE := 'clojerl.Error'} ->
+      'clojerl.Error':'str'(X);
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->
+      'clojerl.ExceptionInfo':'str'(X);
+    #{?TYPE := 'erlang.io.StringWriter'} ->
+      'erlang.io.StringWriter':'str'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'str'(X);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'str'(X);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'str'(X);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'str'(X);
+    #{?TYPE := 'erlang.io.StringReader'} ->
+      'erlang.io.StringReader':'str'(X);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'str'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'str'(X);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'str'(X);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'str'(X);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'str'(X);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'str'(X);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'str'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'str'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'str'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'str'(X);
+    #{?TYPE := 'clojerl.Fn'} ->
+      'clojerl.Fn':'str'(X);
+    #{?TYPE := 'clojerl.IOError'} ->
+      'clojerl.IOError':'str'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'str', X);
     X_ when erlang:is_binary(X_) ->
@@ -136,49 +137,49 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.IOError'} ->  true;
-    #{?TYPE := 'clojerl.Fn'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'erlang.io.StringReader'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'clojerl.Namespace'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
-    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'clojerl.Error'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.Reduced'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'erlang.util.Regex'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
-    #{?TYPE := 'erlang.util.UUID'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'erlang.io.File'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'erlang.Type'} ->  true;
     #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'erlang.Type'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'erlang.io.File'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'erlang.util.UUID'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.AssertionError'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'erlang.util.Regex'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Reduced'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Error'} ->  true;
+    #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
+    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.Namespace'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'erlang.io.StringReader'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
+    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Fn'} ->  true;
+    #{?TYPE := 'clojerl.IOError'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -199,49 +200,49 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.IOError' -> true;
-    'clojerl.Fn' -> true;
-    'clojerl.List' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.Range' -> true;
-    'erlang.io.PushbackReader' -> true;
-    'clojerl.Delay' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.ArityError' -> true;
-    'clojerl.reader.TaggedLiteral' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'erlang.io.StringReader' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'clojerl.Namespace' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.Set' -> true;
-    'erlang.io.StringWriter' -> true;
-    'clojerl.ExceptionInfo' -> true;
-    'clojerl.Error' -> true;
-    'clojerl.Cons' -> true;
-    'clojerl.Symbol' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.Reduced' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'erlang.util.Regex' -> true;
-    'clojerl.ProcessVal' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.AssertionError' -> true;
-    'clojerl.StringSeq' -> true;
-    'erlang.util.UUID' -> true;
-    'clojerl.Repeat' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Cycle' -> true;
-    'erlang.io.File' -> true;
-    'clojerl.SortedMap' -> true;
-    'clojerl.SortedSet' -> true;
-    'erlang.Type' -> true;
     'clojerl.Map' -> true;
+    'erlang.Type' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.SortedMap' -> true;
+    'erlang.io.File' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.Repeat' -> true;
+    'erlang.util.UUID' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.AssertionError' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.ProcessVal' -> true;
+    'erlang.util.Regex' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Reduced' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.Cons' -> true;
+    'clojerl.Error' -> true;
+    'clojerl.ExceptionInfo' -> true;
+    'erlang.io.StringWriter' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.Namespace' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'erlang.io.StringReader' -> true;
+    'clojerl.ChunkedCons' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.reader.TaggedLiteral' -> true;
+    'clojerl.ArityError' -> true;
+    'erlang.util.Date' -> true;
+    'clojerl.Delay' -> true;
+    'erlang.io.PushbackReader' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Fn' -> true;
+    'clojerl.IOError' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'clojerl.Integer' -> true;

--- a/src/erl/lang/protocols/clojerl.IStringable.erl
+++ b/src/erl/lang/protocols/clojerl.IStringable.erl
@@ -15,92 +15,92 @@
 
 'str'(X) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->
-      'clojerl.Map':'str'(X);
-    #{?TYPE := 'erlang.Type'} ->
-      'erlang.Type':'str'(X);
-    #{?TYPE := 'clojerl.SortedSet'} ->
-      'clojerl.SortedSet':'str'(X);
-    #{?TYPE := 'clojerl.SortedMap'} ->
-      'clojerl.SortedMap':'str'(X);
-    #{?TYPE := 'erlang.io.File'} ->
-      'erlang.io.File':'str'(X);
-    #{?TYPE := 'clojerl.Cycle'} ->
-      'clojerl.Cycle':'str'(X);
-    #{?TYPE := 'clojerl.Vector'} ->
-      'clojerl.Vector':'str'(X);
-    #{?TYPE := 'clojerl.Atom'} ->
-      'clojerl.Atom':'str'(X);
-    #{?TYPE := 'clojerl.Repeat'} ->
-      'clojerl.Repeat':'str'(X);
-    #{?TYPE := 'erlang.util.UUID'} ->
-      'erlang.util.UUID':'str'(X);
-    #{?TYPE := 'clojerl.StringSeq'} ->
-      'clojerl.StringSeq':'str'(X);
+    #{?TYPE := 'clojerl.ArityError'} ->
+      'clojerl.ArityError':'str'(X);
     #{?TYPE := 'clojerl.AssertionError'} ->
       'clojerl.AssertionError':'str'(X);
-    #{?TYPE := 'clojerl.TupleMap'} ->
-      'clojerl.TupleMap':'str'(X);
-    #{?TYPE := 'clojerl.ProcessVal'} ->
-      'clojerl.ProcessVal':'str'(X);
-    #{?TYPE := 'erlang.util.Regex'} ->
-      'erlang.util.Regex':'str'(X);
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
-      'clojerl.Vector.ChunkedSeq':'str'(X);
-    #{?TYPE := 'clojerl.Iterate'} ->
-      'clojerl.Iterate':'str'(X);
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->
-      'clojerl.IllegalAccessError':'str'(X);
-    #{?TYPE := 'clojerl.Reduced'} ->
-      'clojerl.Reduced':'str'(X);
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->
-      'clojerl.Vector.RSeq':'str'(X);
-    #{?TYPE := 'clojerl.TransducerSeq'} ->
-      'clojerl.TransducerSeq':'str'(X);
-    #{?TYPE := 'clojerl.Symbol'} ->
-      'clojerl.Symbol':'str'(X);
+    #{?TYPE := 'clojerl.Atom'} ->
+      'clojerl.Atom':'str'(X);
+    #{?TYPE := 'clojerl.BadArgumentError'} ->
+      'clojerl.BadArgumentError':'str'(X);
+    #{?TYPE := 'clojerl.ChunkedCons'} ->
+      'clojerl.ChunkedCons':'str'(X);
     #{?TYPE := 'clojerl.Cons'} ->
       'clojerl.Cons':'str'(X);
+    #{?TYPE := 'clojerl.Cycle'} ->
+      'clojerl.Cycle':'str'(X);
+    #{?TYPE := 'clojerl.Delay'} ->
+      'clojerl.Delay':'str'(X);
     #{?TYPE := 'clojerl.Error'} ->
       'clojerl.Error':'str'(X);
     #{?TYPE := 'clojerl.ExceptionInfo'} ->
       'clojerl.ExceptionInfo':'str'(X);
-    #{?TYPE := 'erlang.io.StringWriter'} ->
-      'erlang.io.StringWriter':'str'(X);
-    #{?TYPE := 'clojerl.Set'} ->
-      'clojerl.Set':'str'(X);
-    #{?TYPE := 'clojerl.BadArgumentError'} ->
-      'clojerl.BadArgumentError':'str'(X);
-    #{?TYPE := 'clojerl.Namespace'} ->
-      'clojerl.Namespace':'str'(X);
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
-      'clojerl.reader.ReaderConditional':'str'(X);
-    #{?TYPE := 'erlang.io.StringReader'} ->
-      'erlang.io.StringReader':'str'(X);
-    #{?TYPE := 'clojerl.ChunkedCons'} ->
-      'clojerl.ChunkedCons':'str'(X);
-    #{?TYPE := 'clojerl.Var'} ->
-      'clojerl.Var':'str'(X);
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
-      'clojerl.reader.TaggedLiteral':'str'(X);
-    #{?TYPE := 'clojerl.ArityError'} ->
-      'clojerl.ArityError':'str'(X);
-    #{?TYPE := 'erlang.util.Date'} ->
-      'erlang.util.Date':'str'(X);
-    #{?TYPE := 'clojerl.Delay'} ->
-      'clojerl.Delay':'str'(X);
-    #{?TYPE := 'erlang.io.PushbackReader'} ->
-      'erlang.io.PushbackReader':'str'(X);
-    #{?TYPE := 'clojerl.Range'} ->
-      'clojerl.Range':'str'(X);
-    #{?TYPE := 'clojerl.LazySeq'} ->
-      'clojerl.LazySeq':'str'(X);
-    #{?TYPE := 'clojerl.List'} ->
-      'clojerl.List':'str'(X);
     #{?TYPE := 'clojerl.Fn'} ->
       'clojerl.Fn':'str'(X);
     #{?TYPE := 'clojerl.IOError'} ->
       'clojerl.IOError':'str'(X);
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->
+      'clojerl.IllegalAccessError':'str'(X);
+    #{?TYPE := 'clojerl.Iterate'} ->
+      'clojerl.Iterate':'str'(X);
+    #{?TYPE := 'clojerl.LazySeq'} ->
+      'clojerl.LazySeq':'str'(X);
+    #{?TYPE := 'clojerl.List'} ->
+      'clojerl.List':'str'(X);
+    #{?TYPE := 'clojerl.Map'} ->
+      'clojerl.Map':'str'(X);
+    #{?TYPE := 'clojerl.Namespace'} ->
+      'clojerl.Namespace':'str'(X);
+    #{?TYPE := 'clojerl.ProcessVal'} ->
+      'clojerl.ProcessVal':'str'(X);
+    #{?TYPE := 'clojerl.Range'} ->
+      'clojerl.Range':'str'(X);
+    #{?TYPE := 'clojerl.Reduced'} ->
+      'clojerl.Reduced':'str'(X);
+    #{?TYPE := 'clojerl.Repeat'} ->
+      'clojerl.Repeat':'str'(X);
+    #{?TYPE := 'clojerl.Set'} ->
+      'clojerl.Set':'str'(X);
+    #{?TYPE := 'clojerl.SortedMap'} ->
+      'clojerl.SortedMap':'str'(X);
+    #{?TYPE := 'clojerl.SortedSet'} ->
+      'clojerl.SortedSet':'str'(X);
+    #{?TYPE := 'clojerl.StringSeq'} ->
+      'clojerl.StringSeq':'str'(X);
+    #{?TYPE := 'clojerl.Symbol'} ->
+      'clojerl.Symbol':'str'(X);
+    #{?TYPE := 'clojerl.TransducerSeq'} ->
+      'clojerl.TransducerSeq':'str'(X);
+    #{?TYPE := 'clojerl.TupleMap'} ->
+      'clojerl.TupleMap':'str'(X);
+    #{?TYPE := 'clojerl.Var'} ->
+      'clojerl.Var':'str'(X);
+    #{?TYPE := 'clojerl.Vector'} ->
+      'clojerl.Vector':'str'(X);
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->
+      'clojerl.Vector.ChunkedSeq':'str'(X);
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->
+      'clojerl.Vector.RSeq':'str'(X);
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->
+      'clojerl.reader.ReaderConditional':'str'(X);
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->
+      'clojerl.reader.TaggedLiteral':'str'(X);
+    #{?TYPE := 'erlang.Type'} ->
+      'erlang.Type':'str'(X);
+    #{?TYPE := 'erlang.io.File'} ->
+      'erlang.io.File':'str'(X);
+    #{?TYPE := 'erlang.io.PushbackReader'} ->
+      'erlang.io.PushbackReader':'str'(X);
+    #{?TYPE := 'erlang.io.StringReader'} ->
+      'erlang.io.StringReader':'str'(X);
+    #{?TYPE := 'erlang.io.StringWriter'} ->
+      'erlang.io.StringWriter':'str'(X);
+    #{?TYPE := 'erlang.util.Date'} ->
+      'erlang.util.Date':'str'(X);
+    #{?TYPE := 'erlang.util.Regex'} ->
+      'erlang.util.Regex':'str'(X);
+    #{?TYPE := 'erlang.util.UUID'} ->
+      'erlang.util.UUID':'str'(X);
     #{?TYPE := _} ->
       clj_protocol:not_implemented(?MODULE, 'str', X);
     X_ when erlang:is_binary(X_) ->
@@ -137,49 +137,49 @@
 
 ?SATISFIES(X) ->
   case X of
-    #{?TYPE := 'clojerl.Map'} ->  true;
-    #{?TYPE := 'erlang.Type'} ->  true;
-    #{?TYPE := 'clojerl.SortedSet'} ->  true;
-    #{?TYPE := 'clojerl.SortedMap'} ->  true;
-    #{?TYPE := 'erlang.io.File'} ->  true;
-    #{?TYPE := 'clojerl.Cycle'} ->  true;
-    #{?TYPE := 'clojerl.Vector'} ->  true;
-    #{?TYPE := 'clojerl.Atom'} ->  true;
-    #{?TYPE := 'clojerl.Repeat'} ->  true;
-    #{?TYPE := 'erlang.util.UUID'} ->  true;
-    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
-    #{?TYPE := 'clojerl.TupleMap'} ->  true;
-    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
-    #{?TYPE := 'erlang.util.Regex'} ->  true;
-    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
-    #{?TYPE := 'clojerl.Iterate'} ->  true;
-    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
-    #{?TYPE := 'clojerl.Reduced'} ->  true;
-    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
-    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
-    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.Atom'} ->  true;
+    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
+    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := 'clojerl.Cons'} ->  true;
+    #{?TYPE := 'clojerl.Cycle'} ->  true;
+    #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Error'} ->  true;
     #{?TYPE := 'clojerl.ExceptionInfo'} ->  true;
-    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
-    #{?TYPE := 'clojerl.Set'} ->  true;
-    #{?TYPE := 'clojerl.BadArgumentError'} ->  true;
-    #{?TYPE := 'clojerl.Namespace'} ->  true;
-    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
-    #{?TYPE := 'erlang.io.StringReader'} ->  true;
-    #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.Var'} ->  true;
-    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
-    #{?TYPE := 'clojerl.ArityError'} ->  true;
-    #{?TYPE := 'erlang.util.Date'} ->  true;
-    #{?TYPE := 'clojerl.Delay'} ->  true;
-    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
-    #{?TYPE := 'clojerl.Range'} ->  true;
-    #{?TYPE := 'clojerl.LazySeq'} ->  true;
-    #{?TYPE := 'clojerl.List'} ->  true;
     #{?TYPE := 'clojerl.Fn'} ->  true;
     #{?TYPE := 'clojerl.IOError'} ->  true;
+    #{?TYPE := 'clojerl.IllegalAccessError'} ->  true;
+    #{?TYPE := 'clojerl.Iterate'} ->  true;
+    #{?TYPE := 'clojerl.LazySeq'} ->  true;
+    #{?TYPE := 'clojerl.List'} ->  true;
+    #{?TYPE := 'clojerl.Map'} ->  true;
+    #{?TYPE := 'clojerl.Namespace'} ->  true;
+    #{?TYPE := 'clojerl.ProcessVal'} ->  true;
+    #{?TYPE := 'clojerl.Range'} ->  true;
+    #{?TYPE := 'clojerl.Reduced'} ->  true;
+    #{?TYPE := 'clojerl.Repeat'} ->  true;
+    #{?TYPE := 'clojerl.Set'} ->  true;
+    #{?TYPE := 'clojerl.SortedMap'} ->  true;
+    #{?TYPE := 'clojerl.SortedSet'} ->  true;
+    #{?TYPE := 'clojerl.StringSeq'} ->  true;
+    #{?TYPE := 'clojerl.Symbol'} ->  true;
+    #{?TYPE := 'clojerl.TransducerSeq'} ->  true;
+    #{?TYPE := 'clojerl.TupleMap'} ->  true;
+    #{?TYPE := 'clojerl.Var'} ->  true;
+    #{?TYPE := 'clojerl.Vector'} ->  true;
+    #{?TYPE := 'clojerl.Vector.ChunkedSeq'} ->  true;
+    #{?TYPE := 'clojerl.Vector.RSeq'} ->  true;
+    #{?TYPE := 'clojerl.reader.ReaderConditional'} ->  true;
+    #{?TYPE := 'clojerl.reader.TaggedLiteral'} ->  true;
+    #{?TYPE := 'erlang.Type'} ->  true;
+    #{?TYPE := 'erlang.io.File'} ->  true;
+    #{?TYPE := 'erlang.io.PushbackReader'} ->  true;
+    #{?TYPE := 'erlang.io.StringReader'} ->  true;
+    #{?TYPE := 'erlang.io.StringWriter'} ->  true;
+    #{?TYPE := 'erlang.util.Date'} ->  true;
+    #{?TYPE := 'erlang.util.Regex'} ->  true;
+    #{?TYPE := 'erlang.util.UUID'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  true;
     X_ when erlang:is_bitstring(X_) ->  true;
@@ -200,49 +200,49 @@
 
 ?EXTENDS(X) ->
   case X of
-    'clojerl.Map' -> true;
-    'erlang.Type' -> true;
-    'clojerl.SortedSet' -> true;
-    'clojerl.SortedMap' -> true;
-    'erlang.io.File' -> true;
-    'clojerl.Cycle' -> true;
-    'clojerl.Vector' -> true;
-    'clojerl.Atom' -> true;
-    'clojerl.Repeat' -> true;
-    'erlang.util.UUID' -> true;
-    'clojerl.StringSeq' -> true;
+    'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
-    'clojerl.TupleMap' -> true;
-    'clojerl.ProcessVal' -> true;
-    'erlang.util.Regex' -> true;
-    'clojerl.Vector.ChunkedSeq' -> true;
-    'clojerl.Iterate' -> true;
-    'clojerl.IllegalAccessError' -> true;
-    'clojerl.Reduced' -> true;
-    'clojerl.Vector.RSeq' -> true;
-    'clojerl.TransducerSeq' -> true;
-    'clojerl.Symbol' -> true;
+    'clojerl.Atom' -> true;
+    'clojerl.BadArgumentError' -> true;
+    'clojerl.ChunkedCons' -> true;
     'clojerl.Cons' -> true;
+    'clojerl.Cycle' -> true;
+    'clojerl.Delay' -> true;
     'clojerl.Error' -> true;
     'clojerl.ExceptionInfo' -> true;
-    'erlang.io.StringWriter' -> true;
-    'clojerl.Set' -> true;
-    'clojerl.BadArgumentError' -> true;
-    'clojerl.Namespace' -> true;
-    'clojerl.reader.ReaderConditional' -> true;
-    'erlang.io.StringReader' -> true;
-    'clojerl.ChunkedCons' -> true;
-    'clojerl.Var' -> true;
-    'clojerl.reader.TaggedLiteral' -> true;
-    'clojerl.ArityError' -> true;
-    'erlang.util.Date' -> true;
-    'clojerl.Delay' -> true;
-    'erlang.io.PushbackReader' -> true;
-    'clojerl.Range' -> true;
-    'clojerl.LazySeq' -> true;
-    'clojerl.List' -> true;
     'clojerl.Fn' -> true;
     'clojerl.IOError' -> true;
+    'clojerl.IllegalAccessError' -> true;
+    'clojerl.Iterate' -> true;
+    'clojerl.LazySeq' -> true;
+    'clojerl.List' -> true;
+    'clojerl.Map' -> true;
+    'clojerl.Namespace' -> true;
+    'clojerl.ProcessVal' -> true;
+    'clojerl.Range' -> true;
+    'clojerl.Reduced' -> true;
+    'clojerl.Repeat' -> true;
+    'clojerl.Set' -> true;
+    'clojerl.SortedMap' -> true;
+    'clojerl.SortedSet' -> true;
+    'clojerl.StringSeq' -> true;
+    'clojerl.Symbol' -> true;
+    'clojerl.TransducerSeq' -> true;
+    'clojerl.TupleMap' -> true;
+    'clojerl.Var' -> true;
+    'clojerl.Vector' -> true;
+    'clojerl.Vector.ChunkedSeq' -> true;
+    'clojerl.Vector.RSeq' -> true;
+    'clojerl.reader.ReaderConditional' -> true;
+    'clojerl.reader.TaggedLiteral' -> true;
+    'erlang.Type' -> true;
+    'erlang.io.File' -> true;
+    'erlang.io.PushbackReader' -> true;
+    'erlang.io.StringReader' -> true;
+    'erlang.io.StringWriter' -> true;
+    'erlang.util.Date' -> true;
+    'erlang.util.Regex' -> true;
+    'erlang.util.UUID' -> true;
     'clojerl.String' -> true;
     'clojerl.BitString' -> true;
     'clojerl.Integer' -> true;

--- a/src/erl/lang/protocols/clojerl.IType.erl
+++ b/src/erl/lang/protocols/clojerl.IType.erl
@@ -10,6 +10,7 @@
 -export([?EXTENDS/1]).
 
 -callback '_'(any()) -> any().
+-optional_callbacks(['_'/1]).
 
 ?SATISFIES(X) ->
   case X of

--- a/test/clj/clojure/test_clojure/protocols.clje
+++ b/test/clj/clojure/test_clojure/protocols.clje
@@ -28,29 +28,29 @@
 (defn find-protocol-impls
   [protocol]
   (let [type->str #(subs (str %) 1)
-        prefix (type->str protocol)
+        prefix (str protocol)
+        ns-name (str/join "." (-> prefix (str/split #"\.") drop-last))
         f (fn [[module path]]
-            (str/starts-with? (type->str module) prefix))]
+            (or (str/starts-with? (type->str module) prefix)
+                (= ns-name (type->str module))))]
     (->> (code/all_loaded)
          (filter f)
-         (map first))))
+         (map (fn [[module _]]
+                [module (type->str module)])))))
 
 (defn clean-protocol [protocol]
-  (doseq [m (find-protocol-impls protocol)]
-    (delete-module m)))
+  (doseq [[module ns-name] (find-protocol-impls protocol)]
+    (clojerl.Namespace/remove (symbol ns-name))
+    (delete-module module)))
 
-;; temporary hack until I decide how to cleanly reload protocol
-;; this no longer works
+;; Upstream Clojure test doesn't have the implementation of
+;; this function figured out. It's unclear how to implement it
+;; for Clojure on the BEAM as well.
+;; This implementation does not work.
 (defn reload-example-protocols
   []
   ;; (clean-protocol ExampleProtocol)
   ;; (clean-protocol other/SimpleProtocol)
-
-  ;; (alter-var-root #'clojure.test-clojure.protocols.examples/ExampleProtocol
-  ;;                 assoc :impls {})
-  ;; (alter-var-root #'clojure.test-clojure.protocols.more-examples/SimpleProtocol
-  ;;                 assoc :impls {})
-
   (require :reload
            'clojure.test-clojure.protocols.examples
            'clojure.test-clojure.protocols.more-examples))
@@ -141,15 +141,6 @@
   (testing "record? and type? return expected result for IRecord and IType"
     (let [r (TestRecord. 1 2)]
       (is (record? r)))))
-
-(deftype ExtendsTestWidget []
-  ExampleProtocol)
-#_(deftest extends?-test
-  (reload-example-protocols)
-  (testing "returns false if a type does not implement the protocol at all"
-    (is (false? (extends? other/SimpleProtocol ExtendsTestWidget))))
-  (testing "returns true if a type implements the protocol directly" ;; semantics changed 4/15/2010
-    (is (true? (extends? ExampleProtocol ExtendsTestWidget)))))
 
 (deftype SatisfiesTestWidget []
   ExampleProtocol)

--- a/test/clj/clojure/test_clojure/protocols.clje
+++ b/test/clj/clojure/test_clojure/protocols.clje
@@ -64,7 +64,8 @@
        (filter (comp not #{"$_clj_on_load"
                            "module_info"
                            "__satisfies?__"
-                           "__extends?__"}))
+                           "__extends?__"
+                           "behaviour_info"}))
        (filter #(not (str/ends-with? % "__val")))
        sort))
 


### PR DESCRIPTION
(#661)

- There is a new special form `behaviour*` which should be used through the macro `erlang.core/behaviours` provided by the (new & experimental) `erlang.core` namespace. This allows specifying that a namespace should implement the provided behaviour(s).
- `erlang.core` also defines `defbehaviour` which allows to specify the callbacks so that the current namespace is defined as a behaviour. Example:
    ```
    (ns some-ns)
    (defbehaviour
      (foo [x])
      (bar [x] ^:optional [x y] [x y x]))
    ```
- Protocols used to be behaviours already, but now all the callbacks are marked as optional.
- Before a module gets compiled into a BEAM binary there is a check for the behaviours it is supposed to implement. The warning for a namespace like this:
    ```
    (ns bar
      (:require [erlang.core :as erl]))
    (erl/behaviours gen_server)
    ```
    Look like this
    ```
    bar.clje:1:1: Missing callback 'handle_cast' (arity 2) for behaviour 'gen_server'
    bar.clje:1:1: Missing callback 'handle_call' (arity 3) for behaviour 'gen_server'
    bar.clje:1:1: Missing callback 'init' (arity 1) for behaviour 'gen_server'
    ```