### PR TITLE
[#679] Emit a remote call to the var when the arity used does not exist

### DIFF
--- a/bootstrap/clojure.core.erl
+++ b/bootstrap/clojure.core.erl
@@ -14,6 +14,7 @@
                              , meta      => #{ macro           => true
                                              , 'variadic?'     => true
                                              , max_fixed_arity => ?NIL
+                                             , fixed_arities   => []
                                              , variadic_arity  => 3
                                              }
                              }
@@ -25,6 +26,7 @@
                              , val_atom  => 'in-ns__val'
                              , meta      => #{ 'variadic?'     => false
                                              , max_fixed_arity => 1
+                                             , fixed_arities   => [1]
                                              , variadic_arity  => ?NIL
                                              }
                              }
@@ -242,6 +244,7 @@ ns__val() ->
   Meta = #{ macro           => true
           , 'variadic?'     => true
           , max_fixed_arity => ?NIL
+          , fixed_arities   => []
           , variadic_arity  => 3
           },
   clj_rt:with_meta(Var, Meta).
@@ -261,6 +264,7 @@ ns__val() ->
   Var = 'clojerl.Var':?CONSTRUCTOR(<<"clojure.core">>, <<"in-ns">>),
   Meta = #{ 'variadic?'     => false
           , max_fixed_arity => 1
+          , fixed_arities   => [1]
           , variadic_arity  => ?NIL
           },
   clj_rt:with_meta(Var, Meta).

--- a/scripts/examples/fn.clje
+++ b/scripts/examples/fn.clje
@@ -354,3 +354,11 @@
 
 (let* [args :foo]
   ((fn* [y] (assert (erlang/=:= args :foo))) 1))
+
+;; [#679] Unreadable error message when calling undefined local function
+
+(def no-args-fn
+  (fn* []))
+
+(def call-no-args-fn-with-one-arg
+  (fn* [] (no-args-fn 1)))

--- a/src/erl/clojerl_expr.hrl
+++ b/src/erl/clojerl_expr.hrl
@@ -41,6 +41,7 @@
                            , form            => any()
                            , tag             => expr()
                            , 'variadic?'     => boolean()
+                           , fixed_arities   => [arity()]
                            , min_fixed_arity => ?NIL | integer()
                            , max_fixed_arity => ?NIL | integer()
                            , variadic_arity  => ?NIL | integer()


### PR DESCRIPTION
### Description

The function call will throw a function undefined error during runtime,
unless the var is dynamic and is bound to a different var. The compiler
could generate a compilation error, but this is not what the Clojure
compiler does in this case, so we stick to that behavior.

Fix #679.