### PR TITLE
[#682] Remove IReduce implementation from clojerl.Cons

### DIFF
--- a/src/erl/lang/collections/clojerl.Cons.erl
+++ b/src/erl/lang/collections/clojerl.Cons.erl
@@ -8,7 +8,6 @@
 -behavior('clojerl.IErl').
 -behavior('clojerl.IHash').
 -behavior('clojerl.IMeta').
--behavior('clojerl.IReduce').
 -behavior('clojerl.ISeq').
 -behavior('clojerl.ISequential').
 -behavior('clojerl.ISeqable').
@@ -25,9 +24,6 @@
 -export([hash/1]).
 -export([ meta/1
         , with_meta/2
-        ]).
--export([ reduce/2
-        , reduce/3
         ]).
 -export([ first/1
         , next/1
@@ -57,12 +53,18 @@
 %% Protocols
 %%------------------------------------------------------------------------------
 
+%% clojerl.ICounted
+
 count(#{?TYPE := ?M, more := More}) ->
   1 + clj_rt:count(More).
+
+%% clojerl.IColl
 
 cons(#{?TYPE := ?M} = Cons, X) -> ?CONSTRUCTOR(X, Cons).
 
 empty(_) -> [].
+
+%% clojerl.IEquiv
 
 equiv( #{?TYPE := ?M, first := FirstX, more := MoreX}
      , #{?TYPE := ?M, first := FirstY, more := MoreY}
@@ -74,6 +76,8 @@ equiv(#{?TYPE := ?M} = Cons, Y) ->
     false -> false
   end.
 
+%% clojerl.IErl
+
 '->erl'(#{?TYPE := ?M} = X, Recursive) ->
   List = to_list(X),
   case Recursive of
@@ -81,29 +85,19 @@ equiv(#{?TYPE := ?M} = Cons, Y) ->
     false -> List
   end.
 
+%% clojerl.IHash
+
 hash(#{?TYPE := ?M, first := First, more := More}) ->
   clj_murmur3:ordered({First, More}).
+
+%% clojerl.IMeta
 
 meta(#{?TYPE := ?M, meta := Meta}) -> Meta.
 
 with_meta(#{?TYPE := ?M} = List, Metadata) ->
   List#{meta => Metadata}.
 
-reduce(#{?TYPE := ?M, first := First, more := More}, F) ->
-  do_reduce(F, First, More).
-
-reduce(#{?TYPE := ?M, first := First, more := More}, F, Init) ->
-  do_reduce(F, Init, clj_rt:cons(First, More)).
-
-do_reduce(_F, Acc, ?NIL) ->
-  Acc;
-do_reduce(F, Acc, Seq) ->
-  First  = clj_rt:first(Seq),
-  Val    = clj_rt:apply(F, [Acc, First]),
-  case 'clojerl.Reduced':is_reduced(Val) of
-    true  -> 'clojerl.Reduced':deref(Val);
-    false -> do_reduce(F, Val, clj_rt:next(Seq))
-  end.
+%% clojerl.ISeq
 
 first(#{?TYPE := ?M, first := First}) -> First.
 
@@ -113,12 +107,18 @@ next(#{?TYPE := ?M, more := More}) -> clj_rt:seq(More).
 more(#{?TYPE := ?M, more := ?NIL}) -> [];
 more(#{?TYPE := ?M, more := More}) -> More.
 
+%% clojerl.ISequential
+
 '_'(_) -> ?NIL.
+
+%% clojerl.ISeqable
 
 seq(#{?TYPE := ?M} = Cons) -> Cons.
 
 to_list(#{?TYPE := ?M, first := First, more := More}) ->
   [First | clj_rt:to_list(More)].
+
+%% clojerl.IStringable
 
 str(#{?TYPE := ?M} = Cons) ->
   clj_rt:print_str(Cons).

--- a/src/erl/lang/protocols/clojerl.IReduce.erl
+++ b/src/erl/lang/protocols/clojerl.IReduce.erl
@@ -18,8 +18,6 @@
   case Coll of
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'reduce'(Coll, Fun);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'reduce'(Coll, Fun);
     #{?TYPE := 'clojerl.Cycle'} ->
       'clojerl.Cycle':'reduce'(Coll, Fun);
     #{?TYPE := 'clojerl.Iterate'} ->
@@ -56,8 +54,6 @@
   case Coll of
     #{?TYPE := 'clojerl.ChunkedCons'} ->
       'clojerl.ChunkedCons':'reduce'(Coll, Fun, Init);
-    #{?TYPE := 'clojerl.Cons'} ->
-      'clojerl.Cons':'reduce'(Coll, Fun, Init);
     #{?TYPE := 'clojerl.Cycle'} ->
       'clojerl.Cycle':'reduce'(Coll, Fun, Init);
     #{?TYPE := 'clojerl.Iterate'} ->
@@ -93,7 +89,6 @@
 ?SATISFIES(X) ->
   case X of
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
-    #{?TYPE := 'clojerl.Cons'} ->  true;
     #{?TYPE := 'clojerl.Cycle'} ->  true;
     #{?TYPE := 'clojerl.Iterate'} ->  true;
     #{?TYPE := 'clojerl.LazySeq'} ->  true;
@@ -114,7 +109,6 @@
 ?EXTENDS(X) ->
   case X of
     'clojerl.ChunkedCons' -> true;
-    'clojerl.Cons' -> true;
     'clojerl.Cycle' -> true;
     'clojerl.Iterate' -> true;
     'clojerl.LazySeq' -> true;

--- a/test/clojerl_Cons_SUITE.erl
+++ b/test/clojerl_Cons_SUITE.erl
@@ -16,7 +16,6 @@
         , seq/1
         , equiv/1
         , cons/1
-        , reduce/1
         , to_erl/1
         , complete_coverage/1
         ]).
@@ -136,20 +135,6 @@ cons(_Config) ->
 
   3    = clj_rt:count(ThreeList),
   true = clj_rt:equiv(clj_rt:to_list(ThreeList), [0, 1, 2]),
-
-  {comments, ""}.
-
--spec reduce(config()) -> result().
-reduce(_Config) ->
-  TenCons = range(1, 10),
-  55 = 'clojerl.IReduce':reduce(TenCons, fun erlang:'+'/2),
-  60 = 'clojerl.IReduce':reduce(TenCons, fun erlang:'+'/2, 5),
-
-  PlusMaxFun = fun
-                 (X, Y) when X < 10 -> X + Y;
-                 (X, _) -> 'clojerl.Reduced':?CONSTRUCTOR(X)
-               end,
-  10 = 'clojerl.IReduce':reduce(TenCons, PlusMaxFun),
 
   {comments, ""}.
 


### PR DESCRIPTION
### Description

Don't implement the `IReduce` protocol for `Cons` cells. Clojure JVM does not do so, it seems to bring no benefits and it was the source of the related bug.

Fixes #682.