### PR TITLE
[#684] Bound value not used in pattern matching

### DIFF
--- a/scripts/examples/case.clje
+++ b/scripts/examples/case.clje
@@ -1,16 +1,22 @@
 (ns examples.case)
 
+(def assert-with-tags
+  (fn* [result & tags]
+       (if result
+         nil
+         (erlang/error #erl[:failed-assertion tags]))))
+
 (let* [x :b
        y (case* x
                 :a 1
                 :b 2
                 :c 3)
        z (case* y
-                x 2
+                x :one
                 #erl [:default :value])]
-  (erlang/display x)
-  (erlang/display y)
-  (erlang/display z))
+  (assert-with-tags (erlang/=:= x :b) :x)
+  (assert-with-tags (erlang/=:= y 2) :y)
+  (assert-with-tags (erlang/=:= z #erl[:default :value]) :z))
 
 (def case-match-ignore
   (fn* [x]
@@ -25,5 +31,16 @@
        (case* x
               #erl[a y a] y)))
 
-;; First and third don't have to be equal
+;; First and third have to be equal
 (let* [2 (case-match #erl[1 2 1])])
+
+;; [#684] Pattern matching ignores existing bound symbol
+
+(def equal?
+  (fn*  [x y]
+        (case* x
+               y :equal
+               _ :not_equal)))
+
+(assert-with-tags (erlang/=:= (equal? 1 1) :equal))
+(assert-with-tags (erlang/=:= (equal? 1 2) :not_equal))

--- a/scripts/examples/receive.clje
+++ b/scripts/examples/receive.clje
@@ -38,4 +38,4 @@
   (erlang/send x :dec)
   (erlang/send x :print)
   (erlang/send x #erl[:get self])
-  (receive* x (prn x)))
+  (receive* msg (prn msg)))

--- a/scripts/examples/try.clje
+++ b/scripts/examples/try.clje
@@ -76,3 +76,14 @@
     (prn e))
   (catch :error e
     (throw :bad-stuff)))
+
+;; [#684] Pattern matching a local
+
+(let* [x 1
+       y (try
+           (throw 1)
+           (catch _ x :one)
+           (catch _ _ :not-one))]
+  (if (erlang/=:= y :one)
+    nil
+    (throw :error)))

--- a/src/erl/clj_analyzer.erl
+++ b/src/erl/clj_analyzer.erl
@@ -637,10 +637,10 @@ is_not_ampersand(X)    ->
 -spec analyze_method_params(['clojerl.Symbol':type()], clj_env:env()) ->
   clj_env:env().
 analyze_method_params(ParamsNames, Env) ->
-  analyze_method_params(false, -1, ParamsNames, Env).
+  analyze_method_params(false, undefined, ParamsNames, Env).
 
 -spec analyze_method_params( boolean()
-                           , -1 | non_neg_integer()
+                           , undefined | non_neg_integer()
                            , ['clojerl.Symbol':type()]
                            , clj_env:env()
                            ) -> clj_env:env().
@@ -653,7 +653,7 @@ analyze_method_params(IsVariadic, Arity, Params, Env0) ->
                      , form        => Pattern
                      , tag         => type_tag(PatExpr)
                      , pattern     => PatExpr
-                     , 'variadic?' => IsVariadic andalso Id == Arity - 1
+                     , 'variadic?' => IsVariadic andalso Id + 1 == Arity
                      , arg_id      => Id
                      , local       => arg
                      },

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -1064,7 +1064,9 @@ ast(#{op := 'catch'} = Expr, State0) ->
   {Guard0, State5}      = pop_ast(ast(GuardExpr, State4)),
   {Body, State6}        = catch_body(StackAst, TempStackAst, BodyExpr, State5),
 
-  {[PatternAst1], PatGuards} = clj_emitter_pattern:patterns([PatternAst0]),
+  { [PatternAst1]
+  , PatGuards
+  } = clj_emitter_pattern:patterns([PatternAst0], locals(Env)),
   VarsAsts = [ClassAst, PatternAst1, TempStackAst],
   Guard1   = clj_emitter_pattern:fold_guards(Guard0, PatGuards),
   Ast      = cerl:ann_c_clause(Ann, VarsAsts, Guard1, Body),

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -879,7 +879,7 @@ ast(#{op := Op} = Expr, State0) when Op =:= 'let'; Op =:= loop ->
       ({var, Var, Init, AnnBinding}, BodyAcc) ->
         cerl:ann_c_let(AnnBinding, [Var], Init, BodyAcc);
       ({_, Pattern, Init, AnnBinding}, BodyAcc) ->
-        {PatArgs, PatGuards} = clj_emitter_pattern:pattern_list([Pattern]),
+        {PatArgs, PatGuards} = clj_emitter_pattern:patterns([Pattern]),
         Guard       = clj_emitter_pattern:fold_guards(PatGuards),
         ClauseAst   = cerl:ann_c_clause(AnnBinding, PatArgs, Guard, BodyAcc),
         BadmatchAst = fail_clause(badmatch, AnnBinding),
@@ -1064,7 +1064,7 @@ ast(#{op := 'catch'} = Expr, State0) ->
   {Guard0, State5}      = pop_ast(ast(GuardExpr, State4)),
   {Body, State6}        = catch_body(StackAst, TempStackAst, BodyExpr, State5),
 
-  {[PatternAst1], PatGuards} = clj_emitter_pattern:pattern_list([PatternAst0]),
+  {[PatternAst1], PatGuards} = clj_emitter_pattern:patterns([PatternAst0]),
   VarsAsts = [ClassAst, PatternAst1, TempStackAst],
   Guard1   = clj_emitter_pattern:fold_guards(Guard0, PatGuards),
   Ast      = cerl:ann_c_clause(Ann, VarsAsts, Guard1, Body),
@@ -1711,7 +1711,9 @@ clause({PatternExpr, BodyExpr}, StateAcc) ->
   {GuardAst0, StateAcc2}     = pop_ast(ast(GuardExpr, StateAcc1)),
   {BodyAst0, StateAcc3}      = pop_ast(ast(BodyExpr, StateAcc2)),
 
-  {[PatternAst1], PatGuards} = clj_emitter_pattern:pattern_list([PatternAst0]),
+  { [PatternAst1]
+  , PatGuards
+  } = clj_emitter_pattern:patterns([PatternAst0], locals(EnvPattern)),
   GuardAst1 = clj_emitter_pattern:fold_guards(GuardAst0, PatGuards),
 
   ClauseAst = cerl:ann_c_clause(AnnPattern, [PatternAst1], GuardAst1, BodyAst0),
@@ -1759,7 +1761,7 @@ method_to_clause(MethodExpr, State0, ClauseFor) ->
                           , length(ParamsExprs)
                           ),
 
-  {PatternArgs, PatternGuards} = clj_emitter_pattern:pattern_list(Args),
+  {PatternArgs, PatternGuards} = clj_emitter_pattern:patterns(Args),
 
   {BodyAst, State2} = pop_ast(ast(BodyExpr, State1)),
 
@@ -2013,6 +2015,14 @@ pop_ast(State = #{asts := Asts}, N, Reverse) ->
   }.
 
 %% ----- Lexical renames -------
+
+-spec locals(clj_env:env()) -> [atom()].
+locals(Env) ->
+  [ clj_rt:keyword(Name)
+    || #{ name       := Name
+        , underscore := false
+        } <- clj_env:get_locals(Env)
+  ].
 
 -spec add_lexical_renames_scope(state()) -> state().
 add_lexical_renames_scope(State = #{lexical_renames := Renames}) ->

--- a/src/erl/clj_emitter_pattern.erl
+++ b/src/erl/clj_emitter_pattern.erl
@@ -1,6 +1,7 @@
 -module(clj_emitter_pattern).
 
--export([ pattern_list/1
+-export([ patterns/1
+        , patterns/2
         , fold_guards/1
         , fold_guards/2
         ]).
@@ -27,8 +28,11 @@ fold_guards(Guard0, PatternGuards) ->
                end,
   lists:foldr(FoldGuards, Guard0, PatternGuards).
 
-pattern_list(Patterns) ->
-  {PatArgs, PatGuards, _, _} = pattern_list(Patterns, []),
+patterns(Patterns) ->
+  patterns(Patterns, []).
+
+patterns(Patterns, KnownVars) ->
+  {PatArgs, PatGuards, _, _} = pattern_list(Patterns, KnownVars),
   {PatArgs, PatGuards}.
 
 %% -----------------------------------------------------------------------------

--- a/src/erl/clj_env.erl
+++ b/src/erl/clj_env.erl
@@ -17,6 +17,7 @@
         , add_locals_scope/1
         , remove_locals_scope/1
         , get_local/2
+        , get_locals/1
         , put_local/3
         , put_locals/2
         , save_locals_scope/1
@@ -104,6 +105,10 @@ restore_locals_scope(#{saved_locals := LocalsCache} = Env) ->
 -spec get_local('clojerl.Symbol':type(), env()) -> any().
 get_local(Sym, _Env = #{locals := Locals}) ->
   clj_scope:get(clj_rt:str(Sym), Locals).
+
+-spec get_locals(env()) -> [any()].
+get_locals(#{locals := Locals}) ->
+  clj_scope:values(Locals).
 
 -spec put_local('clojerl.Symbol':type(), any(), env()) -> env().
 put_local(Sym, Local, Env = #{locals := Locals}) ->

--- a/src/erl/clj_scope.erl
+++ b/src/erl/clj_scope.erl
@@ -11,6 +11,7 @@
         , put/3
         , update/3
         , to_map/2
+        , values/1
         ]).
 
 -type scope() :: #{ parent   => scope() | ?NIL
@@ -53,6 +54,10 @@ put(Map, Scope) ->
 update(Key, Value, Scope) ->
   do_update(Key, Value, Scope).
 
+-spec values(scope()) -> [any()].
+values(Scope) ->
+  do_values([], Scope).
+
 -spec to_map(function(), scope()) -> any().
 to_map(Fun, Scope) ->
   do_to_map(Fun, #{}, Scope).
@@ -91,3 +96,9 @@ do_update(K, V, Scope = #{mappings := Mappings, parent := Parent}) ->
         NewParent -> Scope#{parent => NewParent}
       end
   end.
+
+-spec do_values([any()], scope()) -> [any()].
+do_values(Values, ?NIL) ->
+  Values;
+do_values(Values, #{mappings := Mappings, parent := Parent}) ->
+  do_values(maps:values(Mappings) ++ Values, Parent).

--- a/test/core_eval_SUITE.erl
+++ b/test/core_eval_SUITE.erl
@@ -64,9 +64,9 @@ alias(_Config) ->
                        end,
 
   ct:comment("Alias as an expression"),
-  {illegal_expr, _} = try core_eval:expr(Alias)
-                      catch _:InvalidExpr -> InvalidExpr
-                      end,
+  <<"illegal expression in eval/0">> = try core_eval:expr(Alias)
+                                       catch _:InvalidExpr -> InvalidExpr
+                                       end,
 
   {comments, ""}.
 
@@ -466,9 +466,9 @@ values(_Config) ->
 
 var(_Config) ->
   X     = cerl:c_var(x),
-  {unbound_var, x, _} = try core_eval:expr(X)
-                        catch error:Error -> Error
-                        end,
+  <<"unbound variable x in eval/0">> = try core_eval:expr(X)
+                                       catch error:Error -> Error
+                                       end,
 
   {comments, ""}.
 
@@ -476,18 +476,18 @@ invalid_exprs(_Config) ->
   Foo = cerl:abstract(foo),
 
   Clause = cerl:c_clause([Foo], Foo),
-  {illegal_expr, _} = try core_eval:expr(Clause)
-                      catch _:Error2 -> Error2
-                      end,
+  <<"illegal expression in eval/0">> = try core_eval:expr(Clause)
+                                       catch _:Error2 -> Error2
+                                       end,
 
   Module = cerl:c_module(Foo, [], []),
   {invalid_expr, c_module} = try core_eval:expr(Module)
                              catch _:Error3 -> Error3
                              end,
 
-  {illegal_expr, _} = try core_eval:expr(foo)
-                      catch _:Error4 -> Error4
-                      end,
+  badarg = try core_eval:expr(foo)
+           catch _:Error4 -> Error4
+           end,
 
   {comments, ""}.
 


### PR DESCRIPTION
### Description

Introduces the consideration of locals with the same name as the used variables in patterns. This **applies** to `catch`, `case*` and `receive*` expressions. 

It **does not** apply to `let*` and `loop*` expressions, where new bindings will be created even if the symbol's name is the same. Both `(let* [x 1 x 2] x)` and `(loop* [x 1 x 2] x)` are valid expressions and will return `2`.

Before this PR the patterns that used a variable with a name of an existing local, wheren't taking the value of the local into consideration.

Fixes #684.