### PR TITLE
[#684] List of known variable must be ordset when emitting pattern

### DIFF
--- a/scripts/examples/case.clje
+++ b/scripts/examples/case.clje
@@ -37,10 +37,22 @@
 ;; [#684] Pattern matching ignores existing bound symbol
 
 (def equal?
-  (fn*  [x y]
-        (case* x
-               y :equal
-               _ :not_equal)))
+  (fn* [x y]
+       (case* x
+              y :equal
+              _ :not_equal)))
 
 (assert-with-tags (erlang/=:= (equal? 1 1) :equal))
 (assert-with-tags (erlang/=:= (equal? 1 2) :not_equal))
+
+(def multiple-locals-not-ordered
+  (fn* [t & a]
+       (let* [r 5]
+         (loop* [n 10]
+           (case* n
+                  r #erl[:five n]
+                  _ (recur (erlang/- n 1))
+                  0 :zero)))))
+
+(assert-with-tags (erlang/=:= (multiple-locals-not-ordered 1 1)
+                              #erl[:five 5]))

--- a/src/erl/clj_emitter_pattern.erl
+++ b/src/erl/clj_emitter_pattern.erl
@@ -28,11 +28,16 @@ fold_guards(Guard0, PatternGuards) ->
                end,
   lists:foldr(FoldGuards, Guard0, PatternGuards).
 
+-spec patterns([cerl:cerl()]) ->
+  {[cerl:cerl()], [cerl:cerl()]}.
 patterns(Patterns) ->
   patterns(Patterns, []).
 
+-spec patterns([cerl:cerl()], ordsets:ordset(atom())) ->
+  {[cerl:cerl()], [cerl:cerl()]}.
 patterns(Patterns, KnownVars) ->
-  {PatArgs, PatGuards, _, _} = pattern_list(Patterns, KnownVars),
+  KnownVarsSet = ordsets:from_list(KnownVars),
+  {PatArgs, PatGuards, _, _} = pattern_list(Patterns, KnownVarsSet),
   {PatArgs, PatGuards}.
 
 %% -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Fixes a small bug when emitting patterns, existing locals must be provided as an ordered set.

Related to #684.