### PR TITLE
[#117] Agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ rebar.lock
 *.dump
 ebin/
 result.prev.txt
+erlang_ls.config

--- a/bootstrap/clojure.core.erl
+++ b/bootstrap/clojure.core.erl
@@ -71,6 +71,15 @@
                 , meta      => #{dynamic => true}
                 }
 
+           , <<"*agent*">>  =>
+               #{ ?TYPE     => 'clojerl.Var'
+                , ns        => <<"clojure.core">>
+                , name      => <<"*agent*">>
+                , ns_atom   => 'clojure.core'
+                , name_atom => '*agent*'
+                , val_atom  => '*agent*__val'
+                , meta      => #{dynamic => true}
+                }
            , <<"*assert*">> =>
                #{ ?TYPE     => 'clojerl.Var'
                 , ns        => <<"clojure.core">>
@@ -209,6 +218,7 @@
         , '*compile-protocols-path*__val'/0
         , '*compile-files*__val'/0
 
+        , '*agent*__val'/0
         , '*assert*__val'/0
         , '*read-eval*__val'/0
         , '*command-line-args*__val'/0
@@ -285,6 +295,9 @@ ns__val() ->
 
 '*compile-files*__val'() ->
   var_value(<<"#'clojure.core/*compile-files*">>, false).
+
+'*agent*__val'() ->
+  var_value(<<"#'clojure.core/*agent*">>, ?NIL).
 
 '*assert*__val'() ->
   var_value(<<"#'clojure.core/*assert*">>, true).

--- a/include/clojerl_int.hrl
+++ b/include/clojerl_int.hrl
@@ -57,6 +57,10 @@
 -define(DEBUG_WHEN(Pred, Term), ok).
 -endif.
 
+%% ETS Tables
+
+-define(AGENT_TABLE, 'clojerl.Agent').
+
 %% Chunk size
 
 -define(CHUNK_SIZE, 32).

--- a/src/clj/clojure/core.clje
+++ b/src/clj/clojure/core.clje
@@ -1695,12 +1695,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Refs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn ^{:private true}
   setup-reference [r options]
-  (throw "unimplemented ref")
-  #_(let [opts (apply hash-map options)]
+  (let [opts (apply hash-map options)]
     (when (:meta opts)
-      (.resetMeta r (:meta opts)))
+      (.reset_meta r (:meta opts)))
     (when (:validator opts)
-      (.setValidator r (:validator opts)))
+      (.validator r (:validator opts)))
     r))
 
 (defn agent
@@ -1728,29 +1727,14 @@
   {:added "1.0"
    }
   ([state & options]
-   (throw "unimplemented agent")
-   #_(let [a (new clojure.lang.Agent state)
+   (let [a (new clojerl.Agent state)
          opts (apply hash-map options)]
      (setup-reference a options)
      (when (:error-handler opts)
-       (.setErrorHandler a (:error-handler opts)))
-     (.setErrorMode a (or (:error-mode opts)
-                          (if (:error-handler opts) :continue :fail)))
+       (.error_handler a (:error-handler opts)))
+     (.error_mode a (or (:error-mode opts)
+                        (if (:error-handler opts) :continue :fail)))
      a)))
-
-(defn set-agent-send-executor!
-  "Sets the ExecutorService to be used by send"
-  {:added "1.5"}
-  [executor]
-  (throw "unimplemented agent")
-  #_(set! clojure.lang.Agent/pooledExecutor executor))
-
-(defn set-agent-send-off-executor!
-  "Sets the ExecutorService to be used by send-off"
-  {:added "1.5"}
-  [executor]
-  (throw "unimplemented agent")
-  #_(set! clojure.lang.Agent/soloExecutor executor))
 
 (defn send-via
   "Dispatch an action to an agent. Returns the agent immediately.
@@ -1759,9 +1743,8 @@
 
   (apply action-fn state-of-agent args)"
   {:added "1.5"}
-  [executor a f & args]
-  (throw "unimplemented agent")
-  #_(.dispatch a (binding [*agent* a] (binding-conveyor-fn f)) args executor))
+  [a f & args]
+  (.dispatch a (binding [*agent* a] (binding-conveyor-fn f)) args))
 
 (defn send
   "Dispatch an action to an agent. Returns the agent immediately.
@@ -1771,8 +1754,7 @@
   (apply action-fn state-of-agent args)"
   {:added "1.0"}
   [a f & args]
-  (throw "unimplemented agent")
-  #_(apply send-via clojure.lang.Agent/pooledExecutor a f args))
+  (apply send-via a f args))
 
 (defn send-off
   "Dispatch a potentially blocking action to an agent. Returns the
@@ -1782,8 +1764,7 @@
   (apply action-fn state-of-agent args)"
   {:added "1.0"}
   [a f & args]
-  (throw "unimplemented agent")
-  #_(apply send-via clojure.lang.Agent/soloExecutor a f args))
+  (apply send-via a f args))
 
 (defn release-pending-sends
   "Normally, actions sent directly or indirectly during another action
@@ -1794,8 +1775,7 @@
   occurring, does nothing. Returns the number of actions dispatched."
   {:added "1.0"}
   []
-  (throw "unimplemented agent")
-  #_(clojure.lang.Agent/releasePendingSends))
+  (clojerl.Agent/release_pending_sends))
 
 (defn add-watch
   "Adds a watch function to an agent/atom/var/ref reference. The watch
@@ -1813,15 +1793,15 @@
   the watch mechanism."
   {:added "1.0"}
   [reference key fn]
-  (throw "unimplemented agent/atom/var/ref")
-  #_(.addWatch reference key fn))
+  (throw "unimplemented watches")
+  (.add_watch reference key fn))
 
 (defn remove-watch
   "Removes a watch (set by add-watch) from a reference"
   {:added "1.0"}
   [reference key]
-  (throw "unimplemented agent/atom/var/ref")
-  #_(.removeWatch reference key))
+  (throw "unimplemented watches")
+  (.remove_watch reference key))
 
 (defn agent-error
   "Returns the exception thrown during an asynchronous action of the
@@ -1829,8 +1809,7 @@
   failed."
   {:added "1.2"}
   [a]
-  (throw "unimplemented agent")
-  #_(.getError a))
+  (.error a))
 
 (defn restart-agent
   "When an agent is failed, changes the agent state to new-state and
@@ -1845,8 +1824,7 @@
   {:added "1.2"
    }
   [a, new-state & options]
-  (throw "unimplemented agent")
-  #_(let [opts (apply hash-map options)]
+  (let [opts (apply hash-map options)]
     (.restart a new-state (if (:clear-actions opts) true false))))
 
 (defn set-error-handler!
@@ -1856,16 +1834,14 @@
   agent and the exception."
   {:added "1.2"}
   [a, handler-fn]
-  (throw "unimplemented agent")
-  #_(.setErrorHandler a handler-fn))
+  (.error_handler a handler-fn))
 
 (defn error-handler
   "Returns the error-handler of agent a, or nil if there is none.
   See set-error-handler!"
   {:added "1.2"}
   [a]
-  (throw "unimplemented agent")
-  #_(.getErrorHandler a))
+  (.error_handler a))
 
 (defn set-error-mode!
   "Sets the error-mode of agent a to mode-keyword, which must be
@@ -1881,15 +1857,13 @@
   still work, returning the state of the agent before the error."
   {:added "1.2"}
   [a, mode-keyword]
-  (throw "unimplemented agent")
-  #_(.setErrorMode a mode-keyword))
+  (.error_mode a mode-keyword))
 
 (defn error-mode
   "Returns the error-mode of agent a.  See set-error-mode!"
   {:added "1.2"}
   [a]
-  (throw "unimplemented agent")
-  #_(.getErrorMode a))
+  (.error_mode a))
 
 (defn agent-errors
   "DEPRECATED: Use 'agent-error' instead.
@@ -1908,55 +1882,7 @@
   {:added "1.0"
    :deprecated "1.2"}
   [a]
-  (throw "unimplemented agent")
-  #_(restart-agent a (.deref a)))
-
-(defn shutdown-agents
-  "Initiates a shutdown of the thread pools that back the agent
-  system. Running actions will complete, but no new actions will be
-  accepted"
-  {:added "1.0"}
-  []
-  (throw "unimplemented agent")
-  #_(. clojure.lang.Agent shutdown))
-
-(defn ref
-  "Creates and returns a Ref with an initial value of x and zero or
-  more options (in any order):
-
-  :meta metadata-map
-
-  :validator validate-fn
-
-  :min-history (default 0)
-  :max-history (default 10)
-
-  If metadata-map is supplied, it will become the metadata on the
-  ref. validate-fn must be nil or a side-effect-free fn of one
-  argument, which will be passed the intended new state on any state
-  change. If the new state is unacceptable, the validate-fn should
-  return false or throw an exception. validate-fn will be called on
-  transaction commit, when all refs have their final values.
-
-  Normally refs accumulate history dynamically as needed to deal with
-  read demands. If you know in advance you will need history you can
-  set :min-history to ensure it will be available when first needed (instead
-  of after a read fault). History is limited, and the limit can be set
-  with :max-history."
-  {:added "1.0"
-   }
-  ([x]
-   (throw "unimplemented ref")
-   #_(new clojure.lang.Ref x))
-  ([x & options]
-   (throw "unimplemented ref")
-   #_(let [r  ^clojure.lang.Ref (setup-reference (ref x) options)
-         opts (apply hash-map options)]
-    (when (:max-history opts)
-      (.setMaxHistory r (:max-history opts)))
-    (when (:min-history opts)
-      (.setMinHistory r (:min-history opts)))
-    r)))
+  (restart-agent a (.deref a)))
 
 (defn deref
   "Also reader macro: @ref/@agent/@var/@atom/@delay/@future/@promise. Within a transaction,
@@ -2024,7 +1950,7 @@
   (.reset atom newval))
 
 (defn set-validator!
-  "Sets the validator-fn for a var/ref/agent/atom. validator-fn must be nil or a
+  "Sets the validator-fn for a var/agent/atom. validator-fn must be nil or a
   side-effect-free fn of one argument, which will be passed the intended
   new state on any state change. If the new state is unacceptable, the
   validator-fn should return false or throw an exception. If the current state (root
@@ -2032,15 +1958,13 @@
   will be thrown and the validator will not be changed."
   {:added "1.0"}
   [iref validator-fn]
-  (throw "unimplemented var/ref/agent/atom")
-  #_(. iref (setValidator validator-fn)))
+  (. iref (validator validator-fn)))
 
 (defn get-validator
-  "Gets the validator-fn for a var/ref/agent/atom."
+  "Gets the validator-fn for a var/agent/atom."
   {:added "1.0"}
   [iref]
-  (throw "unimplemented var/ref/agent/atom")
-  #_(. iref (getValidator)))
+  (. iref (validator)))
 
 (defn alter-meta!
   "Atomically sets the metadata for a namespace/var/ref/agent/atom to be:
@@ -2057,113 +1981,6 @@
   {:added "1.0"}
   [^clojerl.IReference iref metadata-map]
   (.reset_meta iref metadata-map))
-
-(defn commute
-  "Must be called in a transaction. Sets the in-transaction-value of
-  ref to:
-
-  (apply fun in-transaction-value-of-ref args)
-
-  and returns the in-transaction-value of ref.
-
-  At the commit point of the transaction, sets the value of ref to be:
-
-  (apply fun most-recently-committed-value-of-ref args)
-
-  Thus fun should be commutative, or, failing that, you must accept
-  last-one-in-wins behavior.  commute allows for more concurrency than
-  ref-set."
-  {:added "1.0"}
-
-  [ref fun & args]
-  (throw "unimplemented ref")
-  #_(. ref (commute fun args)))
-
-(defn alter
-  "Must be called in a transaction. Sets the in-transaction-value of
-  ref to:
-
-  (apply fun in-transaction-value-of-ref args)
-
-  and returns the in-transaction-value of ref."
-  {:added "1.0"}
-  [ref fun & args]
-  (throw "unimplemented ref")
-  #_(. ref (alter fun args)))
-
-(defn ref-set
-  "Must be called in a transaction. Sets the value of ref.
-  Returns val."
-  {:added "1.0"}
-  [ref val]
-  (throw "unimplemented ref")
-  #_(. ref (set val)))
-
-(defn ref-history-count
-  "Returns the history count of a ref"
-  {:added "1.1"}
-  [ref]
-  (throw "unimplemented ref")
-  #_(.getHistoryCount ref))
-
-(defn ref-min-history
-  "Gets the min-history of a ref, or sets it and returns the ref"
-  {:added "1.1"}
-  ([ref]
-   (throw "unimplemented ref")
-   #_(.getMinHistory ref))
-  ([ref n]
-   (throw "unimplemented ref")
-   #_(.setMinHistory ref n)))
-
-(defn ref-max-history
-  "Gets the max-history of a ref, or sets it and returns the ref"
-  {:added "1.1"}
-  ([ref]
-   (throw "unimplemented ref")
-   #_(.getMaxHistory ref))
-  ([ref n]
-   (throw "unimplemented ref")
-   #_(.setMaxHistory ref n)))
-
-(defn ensure
-  "Must be called in a transaction. Protects the ref from modification
-  by other transactions.  Returns the in-transaction-value of
-  ref. Allows for more concurrency than (ref-set ref @ref)"
-  {:added "1.0"}
-  [ref]
-  (throw "unimplemented ref")
-  #_(. ref (touch))
-  #_(. ref (deref)))
-
-(defmacro sync
-  "transaction-flags => TBD, pass nil for now
-
-  Runs the exprs (in an implicit do) in a transaction that encompasses
-  exprs and any nested calls.  Starts a transaction if none is already
-  running on this thread. Any uncaught exception will abort the
-  transaction and flow out of sync. The exprs may be run more than
-  once, but any effects on Refs will be atomic."
-  {:added "1.0"}
-  [flags-ignored-for-now & body]
-  (throw "unimplemented ref")
-  #_`(. clojure.lang.LockingTransaction
-      (runInTransaction (fn [] ~@body))))
-
-
-(defmacro io!
-  "If an io! block occurs in a transaction, throws an
-  error, else runs body in an implicit do. If the
-  first expression in body is a literal string, will use that as the
-  exception message."
-  {:added "1.0"}
-  [& body]
-  (throw "unimplemented ref")
-  #_(let [message (when (string? (first body)) (first body))
-        body (if message (next body) body)]
-    `(if (clojure.lang.LockingTransaction/isRunning)
-       (throw (new IllegalStateException ~(or message "I/O in transaction")))
-       (do ~@body))))
 
 (defn process-val!
   "Creates and returns a ProcessVal with an initial value of val."
@@ -2889,21 +2706,13 @@
   a failed agent is restarted with :clear-actions true."
   {:added "1.0"}
   [& agents]
-  (throw "unimplemented agent")
-  #_(io! "await in transaction"
-    (when *agent*
-      (throw (new Exception "Can't await in agent action")))
-    (let [latch (new java.util.concurrent.CountDownLatch (count agents))
-          count-down (fn [agent] (. latch (countDown)) agent)]
-      (doseq [agent agents]
-        (send agent count-down))
-      (. latch (await)))))
-
-(defn await1 [a]
-  (throw "unimplemented agent")
-  #_(when (pos? (.getQueueCount a))
-    (await a))
-    a)
+  (when *agent*
+    (throw (new clojerl.Error "Can't await in agent action")))
+  (let [latch (new erlang.util.CountDownLatch (count agents))
+        count-down (fn [agent] (. latch (count_down)) agent)]
+    (doseq [a agents]
+      (send a count-down))
+    (. latch (await))))
 
 (defn await-for
   "Blocks the current thread until all actions dispatched thus
@@ -2912,15 +2721,13 @@
   returning due to timeout, logical true otherwise."
   {:added "1.0"}
   [timeout-ms & agents]
-  (throw "unimplemented agent")
-    #_(io! "await-for in transaction"
-     (when *agent*
-       (throw (new Exception "Can't await in agent action")))
-     (let [latch (new java.util.concurrent.CountDownLatch (count agents))
-           count-down (fn [agent] (. latch (countDown)) agent)]
-       (doseq [agent agents]
-           (send agent count-down))
-       (. latch (await  timeout-ms (. java.util.concurrent.TimeUnit MILLISECONDS))))))
+  (when *agent*
+    (throw (new clojerl.Error "Can't await in agent action")))
+  (let [latch (new erlang.util.CountDownLatch (count agents))
+        count-down (fn [agent] (. latch (count_down)) agent)]
+    (doseq [a agents]
+      (send a count-down))
+    (. latch (await timeout-ms))))
 
 (defmacro dotimes
   "bindings => name n
@@ -4231,17 +4038,6 @@
                     v))
                 coll (range (count coll)))
        (map #(if-let [e (find smap %)] (val e) %) coll))))
-
-(defmacro dosync
-  "Runs the exprs (in an implicit do) in a transaction that encompasses
-  exprs and any nested calls.  Starts a transaction if none is already
-  running on this thread. Any uncaught exception will abort the
-  transaction and flow out of dosync. The exprs may be run more than
-  once, but any effects on Refs will be atomic."
-  {:added "1.0"}
-  [& exprs]
-  (throw "unsupported refs")
-  #_`(sync nil ~@exprs))
 
 #_(
     (defn mk-bound-fn

--- a/src/erl/clojerl_sup.erl
+++ b/src/erl/clojerl_sup.erl
@@ -23,6 +23,9 @@ init(_Args) ->
              , #{ id    => 'clojerl.MultiFn'
                 , start => {'clojerl.MultiFn', start_link, []}
                 }
+             , #{ id    => 'clojerl.Agent.Server'
+                , start => {'clojerl.Agent.Server', start_link, []}
+                }
              , #{ id    => 'clojerl.Atom'
                 , start => {'clojerl.Atom', start_link, []}
                 }

--- a/src/erl/erlang/erlang.io.ICloseable.erl
+++ b/src/erl/erlang/erlang.io.ICloseable.erl
@@ -15,6 +15,8 @@
 
 'close'(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'close'(X);
     #{?TYPE := 'clojerl.Delay'} ->
       'clojerl.Delay':'close'(X);
     #{?TYPE := 'clojerl.Future'} ->
@@ -43,6 +45,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Future'} ->  true;
     #{?TYPE := 'clojerl.Promise'} ->  true;
@@ -59,6 +62,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.Delay' -> true;
     'clojerl.Future' -> true;
     'clojerl.Promise' -> true;

--- a/src/erl/erlang/erlang.util.CountDownLatch.erl
+++ b/src/erl/erlang/erlang.util.CountDownLatch.erl
@@ -1,0 +1,88 @@
+-module('erlang.util.CountDownLatch').
+
+-include("clojerl.hrl").
+
+-export([ ?CONSTRUCTOR/1
+        , count_down/1
+        , await/1
+        , await/2
+        ]).
+
+-export([loop/1]).
+
+-type state() :: #{ count   => integer()
+                  , waiting => [{pid(), reference()}]
+                  }.
+
+-type type()  :: #{ ?TYPE => ?M
+                  , pid   => pid()
+                  }.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec ?CONSTRUCTOR(pos_integer()) -> type().
+?CONSTRUCTOR(N) when N > 0 ->
+  State = #{ count   => N
+           , waiting => []
+           },
+  Pid   = proc_lib:spawn(?MODULE, loop, [State]),
+  #{ ?TYPE => ?M
+   , pid   => Pid
+   }.
+
+-spec count_down(type()) -> ?NIL.
+count_down(#{?TYPE := ?M, pid := Pid}) ->
+  Pid ! count_down,
+  ?NIL.
+
+-spec await(type()) -> boolean().
+await(#{?TYPE := ?M} = Latch) ->
+  await(Latch, infinity).
+
+-spec await(type(), timeout()) -> boolean().
+await(#{?TYPE := ?M, pid := Pid}, Timeout) ->
+  case erlang:is_process_alive(Pid) of
+    true ->
+      Ref = erlang:make_ref(),
+      Pid ! {await, erlang:self(), Ref},
+      receive
+        {await, Ref} -> true
+      after
+        Timeout ->
+          Pid ! {remove, erlang:self(), Ref},
+          false
+      end;
+    false ->
+      true
+  end.
+
+%%------------------------------------------------------------------------------
+%% Internal
+%%------------------------------------------------------------------------------
+
+-spec loop(state()) -> ok.
+loop(State0) ->
+  receive
+    count_down ->
+      case maps:get(count, State0) - 1 of
+        0     -> notify(maps:get(waiting, State0));
+        Count -> loop(State0#{count => Count})
+      end;
+    {await, Pid, Ref} ->
+      Waiting = maps:get(waiting, State0),
+      State1  = State0#{waiting => [{Pid, Ref} | Waiting]},
+      loop(State1);
+    {remove, Pid, Ref} ->
+      Waiting = maps:get(waiting, State0),
+      State1  = State0#{waiting => lists:delete({Pid, Ref}, Waiting)},
+      loop(State1)
+  end.
+
+-spec notify([{pid(), reference()}]) -> ok.
+notify([]) ->
+  ok;
+notify([{Pid, Ref} | Rest]) ->
+  Pid ! {await, Ref},
+  notify(Rest).

--- a/src/erl/lang/clojerl.Agent.Server.erl
+++ b/src/erl/lang/clojerl.Agent.Server.erl
@@ -1,0 +1,63 @@
+-module('clojerl.Agent.Server').
+
+-include("clojerl_int.hrl").
+
+-behaviour(gen_server).
+
+-export([create/3]).
+
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-spec create(pid(), binary(), any()) -> {ok, pid()}.
+create(Owner, Id, Value) ->
+  gen_server:call(?MODULE, {create, Owner, Id, Value}).
+
+-spec start_link() -> ignore | {error, term()} | {ok, pid()}.
+start_link() ->
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%------------------------------------------------------------------------------
+%% gen_server callbacks
+%%------------------------------------------------------------------------------
+
+-spec init(term()) -> {ok, #{}}.
+init([]) ->
+  process_flag(trap_exit, true),
+  ?AGENT_TABLE = ets:new(?AGENT_TABLE, [named_table, set, public, {keypos, 1}]),
+  {ok, #{}}.
+
+handle_call({create, Owner, Id, Value}, _From, State0) ->
+  Reply = 'clojerl.Agent':start_link(Owner, Id, Value),
+  State1 = case Reply of
+            {ok, Pid} when is_pid(Pid) -> State0#{Pid => Id};
+             _ -> State0
+          end,
+  {reply, Reply, State1}.
+
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+
+handle_info({'EXIT', Pid, _Reason}, State0) when is_pid(Pid) ->
+  %% Cleanup table
+  Id     = maps:get(Pid, State0, undefined),
+  true   = ets:delete(?AGENT_TABLE, Id),
+  %% Remove process
+  State1 = maps:remove(Pid, State0),
+  {noreply, State1};
+handle_info(_Msg, State) ->
+  {noreply, State}.
+
+terminate(_Msg, State) ->
+  {ok, State}.
+
+code_change(_Msg, _From, State) ->
+  {ok, State}.

--- a/src/erl/lang/clojerl.Agent.erl
+++ b/src/erl/lang/clojerl.Agent.erl
@@ -1,0 +1,385 @@
+-module('clojerl.Agent').
+
+-include("clojerl.hrl").
+-include("clojerl_int.hrl").
+
+-behaviour(gen_server).
+-behavior('erlang.io.ICloseable').
+-behavior('clojerl.IDeref').
+-behavior('clojerl.IEquiv').
+-behavior('clojerl.IHash').
+-behavior('clojerl.IMeta').
+-behavior('clojerl.IReference').
+-behavior('clojerl.IStringable').
+
+%% API
+-export([?CONSTRUCTOR/1]).
+
+-export([ dispatch/3
+        , error/1
+        , error_handler/1
+        , error_handler/2
+        , error_mode/1
+        , error_mode/2
+        , release_pending_sends/0
+        , restart/3
+        , validator/1
+        , validator/2
+        ]).
+
+%% Protocols
+-export([close/1]).
+-export([deref/1]).
+-export([equiv/2]).
+-export([hash/1]).
+-export([ meta/1
+        , with_meta/2
+        ]).
+-export([ alter_meta/3
+        , reset_meta/2
+        ]).
+-export([str/1]).
+
+%% gen_server callbacks
+-export([ start_link/3
+        , init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-define(PENDING_SENDS,  '__pending_sends__').
+
+-type type()        :: #{ ?TYPE => ?M
+                        , id    => binary()
+                        , pid   => pid()
+                        }.
+
+-type error_mode()  :: continue | fail.
+
+-type agent_state() :: #{ value         => any()
+                        , error_handler => any()
+                        , error_mode    => error_mode()
+                        , error         => any()
+                        , validator     => any()
+                        , meta          => any()
+                        }.
+
+-type state()       :: #{ id      => binary()
+                        , owner   => pid()
+                        , monitor => reference()
+                        , queued  => [{Fn :: any(), Args :: any()}]
+                        }.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec ?CONSTRUCTOR(any()) -> type().
+?CONSTRUCTOR(Value) ->
+  UUID      = 'erlang.util.UUID':random(),
+  Id        = 'erlang.util.UUID':str(UUID),
+  {ok, Pid} = 'clojerl.Agent.Server':create(erlang:self(), Id, Value),
+  build(Id, Pid).
+
+-spec dispatch(type(), any(), any()) -> type().
+dispatch(#{?TYPE := ?M, id :=  Id, pid := Pid} = Agent, Fun, Args) ->
+  case is_running_action() of
+    true ->
+      add_pending_send(Fun, Args),
+      Agent;
+    false ->
+      case field(Id, error) of
+        ?NIL ->
+          ok = gen_server:cast(Pid, {send, Fun, Args}),
+          Agent;
+        Error -> erlang:error(Error)
+      end
+  end.
+
+-spec error(type()) -> any().
+error(#{?TYPE := ?M, id := Id}) ->
+  field(Id, error).
+
+-spec error_handler(type()) -> function().
+error_handler(#{?TYPE := ?M, id := Id}) ->
+  field(Id, error_handler).
+
+-spec error_handler(type(), function()) -> any().
+error_handler(#{?TYPE := ?M, pid := Pid}, ErrorHandler) ->
+  field(Pid, error_handler, ErrorHandler).
+
+-spec error_mode(type()) -> atom().
+error_mode(#{?TYPE := ?M, id := Id}) ->
+  field(Id, error_mode).
+
+-spec error_mode(type(), atom()) -> any().
+error_mode(#{?TYPE := ?M, pid := Pid}, ErrorMode) ->
+  field(Pid, error_mode, ErrorMode).
+
+-spec build(binary(), pid()) -> type().
+build(Id, Pid) ->
+  #{ ?TYPE => ?M
+   , id    => Id
+   , pid   => Pid
+   }.
+
+-spec release_pending_sends() -> non_neg_integer().
+release_pending_sends() ->
+  Pid = erlang:self(),
+  case erlang:get(?PENDING_SENDS) of
+    ?NIL -> 0;
+    Pending ->
+      [ gen_server:cast(Pid, {send, Fun, Args})
+        || {Fun, Args} <- lists:reverse(Pending)
+      ],
+      length(Pending)
+  end.
+
+-spec restart(type(), any(), boolean()) -> any().
+restart(#{?TYPE := ?M, id := Id, pid := Pid}, NewValue, ClearActions) ->
+  case field(Id, error) =:= ?NIL of
+    true -> ?ERROR(<<"Agent does not need a restart">>);
+    false ->
+      case gen_server:call(Pid, {restart, NewValue, ClearActions}) of
+        ok -> NewValue;
+        {error, Error} -> erlang:error(Error)
+      end
+  end.
+
+-spec validator(type()) -> any().
+validator(#{?TYPE := ?M, id := Id}) ->
+  field(Id, validator).
+
+-spec validator(type(), function()) -> any().
+validator(#{?TYPE := ?M, pid := Pid}, Validator) ->
+  field(Pid, validator, Validator).
+
+%%------------------------------------------------------------------------------
+%% Protocols
+%%------------------------------------------------------------------------------
+
+%% clojerl.ICloseable
+
+close(#{?TYPE := ?M, pid := Pid}) ->
+  ok = gen_server:stop(Pid),
+  ?NIL.
+
+%% clojerl.IDeref
+
+deref(#{?TYPE := ?M, id := Id}) ->
+  field(Id, value).
+
+%% clojerl.IEquiv
+
+equiv( #{?TYPE := ?M, id := Id1}
+     , #{?TYPE := ?M, id := Id2}
+     ) ->
+  Id1 =:= Id2;
+equiv(_, _) ->
+  false.
+
+%% clojerl.IHash
+
+hash(#{?TYPE := ?M, id := Id}) ->
+  erlang:phash2(Id).
+
+%% clojerl.IMeta
+
+meta(#{?TYPE := ?M, id := Id}) ->
+  field(Id, meta).
+
+with_meta(#{?TYPE := ?M, pid := Pid} = Agent, Meta) ->
+  field(Pid, meta, Meta),
+  Agent.
+
+%% clojerl.IReference
+
+-spec alter_meta(type(), any(), any()) -> any().
+alter_meta(#{?TYPE := ?M, pid := Pid}, Fun, Args) ->
+  gen_server:call(Pid, {alter_meta, Fun, Args}).
+
+-spec reset_meta(type(), any()) -> any().
+reset_meta(#{?TYPE := ?M, pid := Pid}, Meta) ->
+  field(Pid, meta, Meta).
+
+%% clojerl.IStringable
+
+str(#{?TYPE := ?M, id := Id}) ->
+  <<"#<clojerl.Agent ", Id/binary, ">">>.
+
+%%------------------------------------------------------------------------------
+%% gen_server callbacks
+%%------------------------------------------------------------------------------
+
+-spec start_link(pid(), binary(), any()) -> {ok, pid()} | {error, any()}.
+start_link(Owner, Id, Value) ->
+  gen_server:start_link(?MODULE, {Owner, Id, Value}, []).
+
+-spec init({pid(), binary(), any()}) -> {ok, state()}.
+init({Owner, Id, Value}) ->
+  AgentState = default_state(Value),
+  _          = clj_utils:ets_save(?AGENT_TABLE, {Id, AgentState}),
+  Ref        = erlang:monitor(process, Owner),
+  State      = #{ id      => Id
+                , owner   => Owner
+                , monitor => Ref
+                , queued  => []
+                },
+  {ok, State}.
+
+-spec handle_call({restart, any(), boolean()}, any(), state()) ->
+  {reply, any(), state()}.
+handle_call({restart, NewValue, ClearActions}, _From, #{id := Id} = State0) ->
+  {_, AgentState0} = clj_utils:ets_get(?AGENT_TABLE, Id),
+  Reply = try validate(AgentState0, NewValue) of
+            AgentState1 ->
+              X = {Id, AgentState1#{error => ?NIL}},
+              _ = clj_utils:ets_save(?AGENT_TABLE, X),
+              ok
+          catch _:E -> {error, E}
+          end,
+  %% Handle queued actions
+  State1 = case Reply of
+             ok when ClearActions ->
+               State0#{queued => []};
+             ok ->
+               Queued = maps:get(queued, State0),
+               %% Re-cast queued actions
+               [ gen_server:cast(erlang:self(), {send, Fn, Args})
+                 || {Fn, Args} <- lists:reverse(Queued)
+               ],
+               State0#{queued => []};
+             _ ->
+               State0
+           end,
+  {reply, Reply, State1};
+handle_call({set_field, Name, Value}, _From, #{id := Id} = State) ->
+  {_, AgentState} = clj_utils:ets_get(?AGENT_TABLE, Id),
+  _ = clj_utils:ets_save(?AGENT_TABLE, {Id, AgentState#{Name => Value}}),
+  {reply, ok, State};
+handle_call({alter_meta, Fun, Args}, _From, #{id := Id} = State) ->
+  {_, AgentState}  = clj_utils:ets_get(?AGENT_TABLE, Id),
+  #{meta := Meta0} = AgentState,
+  Meta1 = clj_rt:apply(Fun, clj_rt:cons(Meta0, Args)),
+  _ = clj_utils:ets_save(?AGENT_TABLE, {Id, AgentState#{meta => Meta1}}),
+  {reply, Meta1, State}.
+
+-spec handle_cast({send, function(), any()}, state()) ->
+  {noreply, state()}.
+handle_cast({send, Fun, Args}, #{id := Id} = State0) ->
+  {_, AgentState0} = clj_utils:ets_get(?AGENT_TABLE, Id),
+  case AgentState0 of
+    #{error := ?NIL} ->
+      AgentState1 = apply_action(Id, AgentState0, Fun, Args),
+      _           = clj_utils:ets_save(?AGENT_TABLE, {Id, AgentState1}),
+      {noreply, State0};
+    _ ->
+      Queued = maps:get(queued, State0),
+      State1 = State0#{queued => [{Fun, Args} | Queued]},
+      {noreply, State1}
+  end.
+
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({'DOWN', Ref, _, _, Reason}, #{monitor := Ref} = State) ->
+  {stop, Reason, State};
+handle_info(_Msg, State) ->
+  {noreply, State}.
+
+-spec terminate(any(), state()) -> {ok, state()}.
+terminate(_Msg, State) ->
+  {ok, State}.
+
+-spec code_change(any(), any(), state()) ->
+  {ok, state()}.
+code_change(_Msg, _From, State) ->
+  {ok, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal
+%%------------------------------------------------------------------------------
+
+-spec default_state(any()) -> agent_state().
+default_state(Value) ->
+  #{ value         => Value
+   , error_handler => ?NIL
+   , error_mode    => continue
+   , error         => ?NIL
+   , validator     => ?NIL
+   , meta          => ?NIL
+   }.
+
+-spec init_pending_sends() -> ok.
+init_pending_sends() ->
+  erlang:put(?PENDING_SENDS, []),
+  ok.
+
+-spec clear_pending_sends() -> ok.
+clear_pending_sends() ->
+  erlang:erase(?PENDING_SENDS),
+  ok.
+
+-spec is_running_action() -> boolean().
+is_running_action() ->
+  clj_rt:boolean(erlang:get(?PENDING_SENDS)).
+
+-spec add_pending_send(any(), any()) -> ok.
+add_pending_send(Fun, Args) ->
+  case erlang:get(?PENDING_SENDS) of
+    ?NIL    -> [{Fun, Args}];
+    Pending -> erlang:put(?PENDING_SENDS, [{Fun, Args} | Pending])
+  end.
+
+-spec apply_action(binary(), any(), function(), any()) -> any().
+apply_action(Id, #{value := Value0} = AgentState0, Fun, Args) ->
+  try
+    init_pending_sends(),
+    Value1      = clj_rt:apply(Fun, clj_rt:cons(Value0, Args)),
+    AgentState1 = validate(AgentState0, Value1),
+    'clojerl.Agent':release_pending_sends(),
+    AgentState1
+  catch
+    _:Error ->
+      clear_pending_sends(),
+      handle_error(Id, AgentState0, Error),
+      handle_error_mode(AgentState0, Error)
+  after
+      clear_pending_sends()
+  end.
+
+-spec validate(any(), any()) -> any().
+validate(#{validator := ?NIL} = AgentState, Value) ->
+  AgentState#{value => Value};
+validate(#{validator := Validator} = AgentState, Value) ->
+  case clj_rt:apply(Validator, [Value]) of
+    true  -> AgentState#{value => Value};
+    false -> ?ERROR(validation_failed)
+  end.
+
+-spec handle_error(binary(), any(), any()) -> any().
+handle_error(_Id, #{error_handler := ?NIL}, _Error) ->
+  ok;
+handle_error(Id, #{error_handler := ErrorHandler}, Error) ->
+  try
+    Agent = build(Id, erlang:self()),
+    clj_rt:apply(ErrorHandler, [Agent, Error])
+  catch _:_ -> ok %% ignore ErrorHandler errors
+  end.
+
+-spec handle_error_mode(any(), any()) -> any().
+handle_error_mode(#{error_mode := continue} = AgentState, _Error) ->
+  AgentState;
+handle_error_mode(#{error_mode := fail} = AgentState, Error) ->
+  AgentState#{error => Error}.
+
+-spec field(binary(), atom()) -> any().
+field(Id, Name) ->
+  {_, AgentState} = clj_utils:ets_get(?AGENT_TABLE, Id),
+  maps:get(Name, AgentState, ?NIL).
+
+-spec field(pid(), atom(), any()) -> any().
+field(Pid, Name, Value) ->
+  ok = gen_server:call(Pid, {set_field, Name, Value}),
+  Value.

--- a/src/erl/lang/protocols/clojerl.IDeref.erl
+++ b/src/erl/lang/protocols/clojerl.IDeref.erl
@@ -15,6 +15,8 @@
 
 'deref'(Ref) ->
   case Ref of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'deref'(Ref);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'deref'(Ref);
     #{?TYPE := 'clojerl.Delay'} ->
@@ -43,6 +45,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
     #{?TYPE := 'clojerl.Delay'} ->  true;
     #{?TYPE := 'clojerl.Future'} ->  true;
@@ -59,6 +62,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.Atom' -> true;
     'clojerl.Delay' -> true;
     'clojerl.Future' -> true;

--- a/src/erl/lang/protocols/clojerl.IEquiv.erl
+++ b/src/erl/lang/protocols/clojerl.IEquiv.erl
@@ -15,6 +15,8 @@
 
 'equiv'(X, Y) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'equiv'(X, Y);
     #{?TYPE := 'clojerl.ArityError'} ->
       'clojerl.ArityError':'equiv'(X, Y);
     #{?TYPE := 'clojerl.AssertionError'} ->
@@ -107,6 +109,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
@@ -155,6 +158,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
     'clojerl.Atom' -> true;

--- a/src/erl/lang/protocols/clojerl.IHash.erl
+++ b/src/erl/lang/protocols/clojerl.IHash.erl
@@ -15,6 +15,8 @@
 
 'hash'(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'hash'(X);
     #{?TYPE := 'clojerl.ArityError'} ->
       'clojerl.ArityError':'hash'(X);
     #{?TYPE := 'clojerl.AssertionError'} ->
@@ -131,6 +133,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
@@ -191,6 +194,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
     'clojerl.Atom' -> true;

--- a/src/erl/lang/protocols/clojerl.IMeta.erl
+++ b/src/erl/lang/protocols/clojerl.IMeta.erl
@@ -16,6 +16,8 @@
 
 'meta'(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'meta'(X);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'meta'(X);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
@@ -70,6 +72,8 @@
 
 'with_meta'(X, Meta) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'with_meta'(X, Meta);
     #{?TYPE := 'clojerl.Atom'} ->
       'clojerl.Atom':'with_meta'(X, Meta);
     #{?TYPE := 'clojerl.ChunkedCons'} ->
@@ -124,6 +128,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
     #{?TYPE := 'clojerl.ChunkedCons'} ->  true;
     #{?TYPE := 'clojerl.Cons'} ->  true;
@@ -153,6 +158,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.Atom' -> true;
     'clojerl.ChunkedCons' -> true;
     'clojerl.Cons' -> true;

--- a/src/erl/lang/protocols/clojerl.IReference.erl
+++ b/src/erl/lang/protocols/clojerl.IReference.erl
@@ -16,6 +16,8 @@
 
 'alter_meta'(Ref, Fun, Args) ->
   case Ref of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'alter_meta'(Ref, Fun, Args);
     #{?TYPE := 'clojerl.Namespace'} ->
       'clojerl.Namespace':'alter_meta'(Ref, Fun, Args);
     #{?TYPE := _} ->
@@ -32,6 +34,8 @@
 
 'reset_meta'(Ref, Meta) ->
   case Ref of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'reset_meta'(Ref, Meta);
     #{?TYPE := 'clojerl.Namespace'} ->
       'clojerl.Namespace':'reset_meta'(Ref, Meta);
     #{?TYPE := _} ->
@@ -48,6 +52,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.Namespace'} ->  true;
     #{?TYPE := _} ->  false;
     X_ when erlang:is_binary(X_) ->  false;
@@ -58,6 +63,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.Namespace' -> true;
     _ -> false
   end.

--- a/src/erl/lang/protocols/clojerl.IStringable.erl
+++ b/src/erl/lang/protocols/clojerl.IStringable.erl
@@ -15,6 +15,8 @@
 
 'str'(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->
+      'clojerl.Agent':'str'(X);
     #{?TYPE := 'clojerl.ArityError'} ->
       'clojerl.ArityError':'str'(X);
     #{?TYPE := 'clojerl.AssertionError'} ->
@@ -141,6 +143,7 @@
 
 ?SATISFIES(X) ->
   case X of
+    #{?TYPE := 'clojerl.Agent'} ->  true;
     #{?TYPE := 'clojerl.ArityError'} ->  true;
     #{?TYPE := 'clojerl.AssertionError'} ->  true;
     #{?TYPE := 'clojerl.Atom'} ->  true;
@@ -206,6 +209,7 @@
 
 ?EXTENDS(X) ->
   case X of
+    'clojerl.Agent' -> true;
     'clojerl.ArityError' -> true;
     'clojerl.AssertionError' -> true;
     'clojerl.Atom' -> true;

--- a/test/clj/clojure/test_clojure/agents.clje
+++ b/test/clj/clojure/test_clojure/agents.clje
@@ -1,0 +1,195 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+;; Author: Shawn Hoover
+
+(ns clojure.test-clojure.agents
+  (:use clojure.test)
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; tests are fragile. If wait fails, could indicate that
+;; build box is thrashing.
+(def fragile-wait 1000)
+
+(deftest handle-all-throwables-during-agent-actions
+  ;; Bug fixed in r1198; previously hung Clojure or didn't report agent errors
+  ;; after OutOfMemoryError, yet wouldn't execute new actions.
+  (let [agt (agent nil)]
+    (send agt (fn [state] (throw (Throwable. "just testing Throwables"))))
+    (try
+     ;; Let the action finish; eat the "agent has errors" error that bubbles up
+     (await-for fragile-wait agt)
+     (catch RuntimeException _))
+    (is (instance? Throwable (first (agent-errors agt))))
+    (is (= 1 (count (agent-errors agt))))
+
+    ;; And now send an action that should work
+    (clear-agent-errors agt)
+    (is (= nil @agt))
+    (send agt nil?)
+    (is (true? (await-for fragile-wait agt)))
+    (is (true? @agt))))
+
+(deftest default-modes
+  (is (= :fail (error-mode (agent nil))))
+  (is (= :continue (error-mode (agent nil :error-handler println)))))
+
+(deftest continue-handler
+  (let [err (atom nil)
+        agt (agent 0 :error-mode :continue :error-handler #(reset! err %&))]
+    (send agt /)
+    (is (true? (await-for fragile-wait agt)))
+    (is (= 0 @agt))
+    (is (nil? (agent-error agt)))
+    (is (= agt (first @err)))
+  (is (true? (instance? ArithmeticException (second @err))))))
+
+
+;; TODO: make these tests deterministic (i.e. not sleep and hope)
+
+#_(deftest fail-handler
+  (let [err (atom nil)
+        agt (agent 0 :error-mode :fail :error-handler #(reset! err %&))]
+    (send agt /)
+    (Thread/sleep 100)
+    (is (true? (instance? ArithmeticException (agent-error agt))))
+    (is (= 0 @agt))
+    (is (= agt (first @err)))
+    (is (true? (instance? ArithmeticException (second @err))))
+    (is (thrown? RuntimeException (send agt inc)))))
+
+(deftest can-send-from-error-handler-before-popping-action-that-caused-error
+  (let [latch (CountDownLatch. 1)
+        target-agent (agent :before-error)
+        handler (fn [agt err]
+                  (send target-agent
+                        (fn [_] (.countDown latch))))
+        failing-agent (agent nil :error-handler handler)]
+    (send failing-agent (fn [_] (throw (RuntimeException.))))
+    (is (.await latch 10 TimeUnit/SECONDS))))
+
+(deftest can-send-to-self-from-error-handler-before-popping-action-that-caused-error
+  (let [latch (CountDownLatch. 1)
+        handler (fn [agt err]
+                  (send *agent*
+                        (fn [_] (.countDown latch))))
+        failing-agent (agent nil :error-handler handler)]
+    (send failing-agent (fn [_] (throw (RuntimeException.))))
+    (is (.await latch 10 TimeUnit/SECONDS))))
+
+#_(deftest restart-no-clear
+  (let [p (promise)
+        agt (agent 1 :error-mode :fail)]
+    (send agt (fn [v] @p))
+    (send agt /)
+    (send agt inc)
+    (send agt inc)
+    (deliver p 0)
+    (Thread/sleep 100)
+    (is (= 0 @agt))
+    (is (= ArithmeticException (class (agent-error agt))))
+    (restart-agent agt 10)
+    (is (true? (await-for fragile-wait agt)))
+    (is (= 12 @agt))
+    (is (nil? (agent-error agt)))))
+
+#_(deftest restart-clear
+  (let [p (promise)
+        agt (agent 1 :error-mode :fail)]
+    (send agt (fn [v] @p))
+    (send agt /)
+    (send agt inc)
+    (send agt inc)
+    (deliver p 0)
+    (Thread/sleep 100)
+    (is (= 0 @agt))
+    (is (= ArithmeticException (class (agent-error agt))))
+    (restart-agent agt 10 :clear-actions true)
+    (is (true? (await-for fragile-wait agt)))
+    (is (= 10 @agt))
+    (is (nil? (agent-error agt)))
+    (send agt inc)
+    (is (true? (await-for fragile-wait agt)))
+    (is (= 11 @agt))
+    (is (nil? (agent-error agt)))))
+
+#_(deftest invalid-restart
+  (let [p (promise)
+        agt (agent 2 :error-mode :fail :validator even?)]
+    (is (thrown? RuntimeException (restart-agent agt 4)))
+    (send agt (fn [v] @p))
+    (send agt (partial + 2))
+    (send agt (partial + 2))
+    (deliver p 3)
+    (Thread/sleep 100)
+    (is (= 2 @agt))
+    (is (= IllegalStateException (class (agent-error agt))))
+    (is (thrown? RuntimeException (restart-agent agt 5)))
+    (restart-agent agt 6)
+    (is (true? (await-for fragile-wait agt)))
+    (is (= 10 @agt))
+    (is (nil? (agent-error agt)))))
+
+(deftest earmuff-agent-bound
+  (let [a (agent 1)]
+    (send a (fn [_] *agent*))
+    (await a)
+    (is (= a @a))))
+
+(def ^:dynamic *bind-me* :root-binding)
+
+(deftest thread-conveyance-to-agents
+  (let [a (agent nil)]
+    (doto (Thread.
+           (fn []
+             (binding [*bind-me* :thread-binding]
+               (send a (constantly *bind-me*)))
+             (await a)))
+      (.start)
+      (.join))
+    (is (= @a :thread-binding))))
+
+;; check for a race condition that was causing seque to leak threads from the
+;; send-off pool. Specifically, if we consume all items from the seque, and
+;; the LBQ continues to grow, it means there was an agent action blocking on
+;; the .put, which would block indefinitely outside of this test.
+(deftest seque-threads
+  (let [queue-size 5
+        slow-seq (for [x (take (* 2 queue-size) (iterate inc 0))]
+                   (do (Thread/sleep 25)
+                       x))
+        small-lbq (java.util.concurrent.LinkedBlockingQueue. queue-size)
+        worker (seque small-lbq slow-seq)]
+    (dorun worker)
+    (is (= worker slow-seq))
+    (Thread/sleep 250) ;; make sure agents have time to run or get blocked
+    (let [queue-backlog (.size small-lbq)]
+      (is (<= 0 queue-backlog queue-size))
+      (when-not (zero? queue-backlog)
+        (.take small-lbq)
+        (Thread/sleep 250) ;; see if agent was blocking, indicating a thread leak
+        (is (= (.size small-lbq)
+               (dec queue-backlog)))))))
+
+;; Check for a deadlock condition when one seque was fed into another
+;; seque.  Note that this test does not throw an exception or
+;; otherwise fail if the issue is not fixed -- it simply deadlocks and
+;; hangs until killed.
+(deftest seque-into-seque-deadlock
+  (is (= (range 10) (seque 3 (seque 3 (range 10))))))
+
+; http://clojure.org/agents
+
+; agent
+; deref, @-reader-macro, agent-errors
+; send send-off clear-agent-errors
+; await await-for
+; set-validator get-validator
+; add-watch remove-watch
+; shutdown-agents
+

--- a/test/clj/clojure/test_clojure/agents.clje
+++ b/test/clj/clojure/test_clojure/agents.clje
@@ -10,7 +10,7 @@
 
 (ns clojure.test-clojure.agents
   (:use clojure.test)
-  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+  (:import [erlang.util CountDownLatch]))
 
 ;; tests are fragile. If wait fails, could indicate that
 ;; build box is thrashing.
@@ -20,12 +20,12 @@
   ;; Bug fixed in r1198; previously hung Clojure or didn't report agent errors
   ;; after OutOfMemoryError, yet wouldn't execute new actions.
   (let [agt (agent nil)]
-    (send agt (fn [state] (throw (Throwable. "just testing Throwables"))))
+    (send agt (fn [state] (throw (clojerl.Error. "just testing Errors"))))
     (try
      ;; Let the action finish; eat the "agent has errors" error that bubbles up
      (await-for fragile-wait agt)
-     (catch RuntimeException _))
-    (is (instance? Throwable (first (agent-errors agt))))
+     (catch _ _))
+    (is (instance? clojerl.Error (first (agent-errors agt))))
     (is (= 1 (count (agent-errors agt))))
 
     ;; And now send an action that should work
@@ -47,7 +47,7 @@
     (is (= 0 @agt))
     (is (nil? (agent-error agt)))
     (is (= agt (first @err)))
-  (is (true? (instance? ArithmeticException (second @err))))))
+  (is (= :badarith (second @err)))))
 
 
 ;; TODO: make these tests deterministic (i.e. not sleep and hope)
@@ -56,11 +56,11 @@
   (let [err (atom nil)
         agt (agent 0 :error-mode :fail :error-handler #(reset! err %&))]
     (send agt /)
-    (Thread/sleep 100)
-    (is (true? (instance? ArithmeticException (agent-error agt))))
+    (timer/sleep 100)
+    (is (= :badarith (agent-error agt)))
     (is (= 0 @agt))
     (is (= agt (first @err)))
-    (is (true? (instance? ArithmeticException (second @err))))
+    (is (= :badarith (second @err)))
     (is (thrown? RuntimeException (send agt inc)))))
 
 (deftest can-send-from-error-handler-before-popping-action-that-caused-error
@@ -68,19 +68,19 @@
         target-agent (agent :before-error)
         handler (fn [agt err]
                   (send target-agent
-                        (fn [_] (.countDown latch))))
+                        (fn [_] (.count_down latch))))
         failing-agent (agent nil :error-handler handler)]
-    (send failing-agent (fn [_] (throw (RuntimeException.))))
-    (is (.await latch 10 TimeUnit/SECONDS))))
+    (send failing-agent (fn [_] (throw (clojerl.Error. "error"))))
+    (is (.await latch 10))))
 
 (deftest can-send-to-self-from-error-handler-before-popping-action-that-caused-error
   (let [latch (CountDownLatch. 1)
         handler (fn [agt err]
                   (send *agent*
-                        (fn [_] (.countDown latch))))
+                        (fn [_] (.count_down latch))))
         failing-agent (agent nil :error-handler handler)]
-    (send failing-agent (fn [_] (throw (RuntimeException.))))
-    (is (.await latch 10 TimeUnit/SECONDS))))
+    (send failing-agent (fn [_] (throw (clojerl.Error. "error"))))
+    (is (.await latch 10))))
 
 #_(deftest restart-no-clear
   (let [p (promise)
@@ -143,7 +143,7 @@
 
 (def ^:dynamic *bind-me* :root-binding)
 
-(deftest thread-conveyance-to-agents
+#_(deftest thread-conveyance-to-agents
   (let [a (agent nil)]
     (doto (Thread.
            (fn []
@@ -158,7 +158,7 @@
 ;; send-off pool. Specifically, if we consume all items from the seque, and
 ;; the LBQ continues to grow, it means there was an agent action blocking on
 ;; the .put, which would block indefinitely outside of this test.
-(deftest seque-threads
+#_(deftest seque-threads
   (let [queue-size 5
         slow-seq (for [x (take (* 2 queue-size) (iterate inc 0))]
                    (do (Thread/sleep 25)
@@ -180,7 +180,7 @@
 ;; seque.  Note that this test does not throw an exception or
 ;; otherwise fail if the issue is not fixed -- it simply deadlocks and
 ;; hangs until killed.
-(deftest seque-into-seque-deadlock
+#_(deftest seque-into-seque-deadlock
   (is (= (range 10) (seque 3 (seque 3 (range 10))))))
 
 ; http://clojure.org/agents
@@ -192,4 +192,3 @@
 ; set-validator get-validator
 ; add-watch remove-watch
 ; shutdown-agents
-

--- a/test/clj_test_utils.erl
+++ b/test/clj_test_utils.erl
@@ -6,6 +6,7 @@
         , all/2
         , init_per_suite/1
         , relative_path/1
+        , wait_for/2
         , wait_for/3
         ]).
 
@@ -27,6 +28,10 @@ init_per_suite(Config) ->
 relative_path(Path) ->
   Root = list_to_binary(code:lib_dir(clojerl)),
   <<Root/binary, "/", Path/binary>>.
+
+-spec wait_for(any(), timeout()) -> ok | timeout.
+wait_for(Msg, Timeout) ->
+  wait_for(Msg, 1, Timeout).
 
 -spec wait_for(any(), integer(), timeout()) -> ok | timeout.
 wait_for(_Msg, 0, _Timeout) ->

--- a/test/clojerl_Agent_SUITE.erl
+++ b/test/clojerl_Agent_SUITE.erl
@@ -1,0 +1,322 @@
+-module(clojerl_Agent_SUITE).
+
+-include("clojerl.hrl").
+-include("clojerl_int.hrl").
+-include("clj_test_utils.hrl").
+
+-export([ all/0
+        , init_per_suite/1
+        , end_per_suite/1
+        ]).
+
+-export([ close/1
+        , deref/1
+        , error_handler/1
+        , equiv/1
+        , meta/1
+        , restart/1
+        , release_pending/1
+        , str/1
+        , validator/1
+        , complete_coverage/1
+        ]).
+
+-spec all() -> [atom()].
+all() -> clj_test_utils:all(?MODULE).
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) -> clj_test_utils:init_per_suite(Config).
+
+-spec end_per_suite(config()) -> config().
+end_per_suite(Config) -> Config.
+
+%%------------------------------------------------------------------------------
+%% Test Cases
+%%------------------------------------------------------------------------------
+
+-spec close(config()) -> result().
+close(_Config) ->
+  0     = ets:info(?AGENT_TABLE, size),
+  Count = length(erlang:processes()),
+
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  1     = ets:info(?AGENT_TABLE, size),
+  Count = length(erlang:processes()) - 1,
+
+  ?NIL  = 'clojerl.Agent':close(Agent),
+
+  ok    = timer:sleep(100),
+
+  0     = ets:info(?AGENT_TABLE, size),
+  Count = length(erlang:processes()),
+
+  {comments, ""}.
+
+-spec deref(config()) -> result().
+deref(_Config) ->
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  ct:comment("deref an agent"),
+  1 = clj_rt:deref(Agent),
+
+  ct:comment("deref an agent after applying action"),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun erlang:'+'/2, [1]),
+  ok    = sync(Agent, 1000),
+  2     = clj_rt:deref(Agent),
+
+  {comments, ""}.
+
+-spec error_handler(config()) -> result().
+error_handler(_Config) ->
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  ct:comment("Error handler is called when error happens"),
+  Self  = erlang:self(),
+  Ref   = erlang:make_ref(),
+  ErrorHandler = fun(_Agent, _Err) -> Self ! Ref end,
+  ErrorHandler = 'clojerl.Agent':error_handler(Agent, ErrorHandler),
+  Agent    = 'clojerl.Agent':dispatch(Agent, fun(_) -> throw(foo) end, []),
+  %% Expect message from the error handler
+  ok       = clj_test_utils:wait_for(Ref, 1000),
+  continue = 'clojerl.Agent':error_mode(Agent),
+  ?NIL     = 'clojerl.Agent':error(Agent),
+
+  ct:comment("Error handler is what has been previously set"),
+  ErrorHandler = 'clojerl.Agent':error_handler(Agent),
+
+  ct:comment("Error handler generates an error but it's ignored"),
+  ErrorHandlerFails = fun(_Agent, _Err) -> Self ! Ref, throw(handler) end,
+  ErrorHandlerFails = 'clojerl.Agent':error_handler(Agent, ErrorHandlerFails),
+  Agent    = 'clojerl.Agent':dispatch(Agent, fun(_) -> throw(foo) end, []),
+  ok       = clj_test_utils:wait_for(Ref, 1000),
+  continue = 'clojerl.Agent':error_mode(Agent),
+  ?NIL     = 'clojerl.Agent':error(Agent),
+
+  {comments, ""}.
+
+-spec equiv(config()) -> result().
+equiv(_Config) ->
+  Agent1 = 'clojerl.Agent':?CONSTRUCTOR(1),
+  Agent2 = 'clojerl.Agent':?CONSTRUCTOR(2),
+
+  ct:comment("Check that the same atom with different meta is equivalent"),
+  Agent3 = clj_rt:with_meta(Agent1, #{a => 1}),
+  Agent4 = clj_rt:with_meta(Agent1, #{b => 2}),
+  true  = clj_rt:equiv(Agent3, Agent4),
+
+  ct:comment("Check that different atoms are not equivalent"),
+  false = clj_rt:equiv(Agent1, Agent2),
+
+  ct:comment("An atom and something else"),
+  false = clj_rt:equiv(Agent1, whatever),
+  false = clj_rt:equiv(Agent1, #{}),
+  false = clj_rt:equiv(Agent1, 1),
+
+  {comments, ""}.
+
+-spec meta(config()) -> result().
+meta(_Config) ->
+  Agent     = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  ct:comment("Change using with_meta"),
+  Agent     = clj_rt:with_meta(Agent, #{a => 1}),
+  #{a := 1} = clj_rt:meta(Agent),
+
+  ct:comment("Change using reset_meta"),
+  ?NIL      = 'clojerl.Agent':reset_meta(Agent, ?NIL),
+  ?NIL      = clj_rt:meta(Agent),
+  #{a := 1} = 'clojerl.Agent':reset_meta(Agent, #{a => 1}),
+  #{a := 1} = clj_rt:meta(Agent),
+
+  ct:comment("Alter meta successfully"),
+  AlterFun  = fun(X) -> maps:put(b, 2, X) end,
+  #{a := 1, b := 2} = 'clojerl.Agent':alter_meta(Agent, AlterFun, []),
+  #{a := 1, b := 2} = clj_rt:meta(Agent),
+
+  ct:comment("Alter function generates error, meta doesn't change"),
+  ErrorFun  = fun(_X) -> error(foo) end,
+  ok        = try 'clojerl.Agent':alter_meta(Agent, ErrorFun, []), error
+              catch error:foo -> ok
+              end,
+  #{a := 1, b := 2} = clj_rt:meta(Agent),
+
+  {comments, ""}.
+
+-spec restart(config()) -> result().
+restart(_Config) ->
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+  fail  = 'clojerl.Agent':error_mode(Agent, fail),
+
+  ct:comment("Agent does not need restart"),
+  ok    = try 'clojerl.Agent':restart(Agent, 2, false), error
+          catch _:_ -> ok
+          end,
+
+  ct:comment("Send failing action"),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun(_) -> throw(foo) end, []),
+  %% We don't expect an async reply since the state will be failed
+  _     = sync(Agent, 0),
+  true  = 'clojerl.Agent':error(Agent) =/= ?NIL,
+
+  ct:comment("Dispatch causes error when agent failed"),
+  ok    = try 'clojerl.Agent':dispatch(Agent, fun(_) -> 42 end, []), error
+          catch _:_ -> ok
+          end,
+
+  ct:comment("No error after restart"),
+  2     = 'clojerl.Agent':restart(Agent, 2, false),
+  ?NIL  = 'clojerl.Agent':error(Agent),
+
+  ct:comment("Send failing action and restart with invalid value"),
+  %% Add validator
+  Valid = fun(X) -> X < 3 end,
+  Valid = 'clojerl.Agent':validator(Agent, Valid),
+  %% Generate error
+  Agent = 'clojerl.Agent':dispatch(Agent, fun(_) -> throw(foo) end, []),
+  _     = sync(Agent, 0),
+  true  = 'clojerl.Agent':error(Agent) =/= ?NIL,
+  %% Restart with invalid value
+  ok    = try 'clojerl.Agent':restart(Agent, 42, false), error
+          catch _:_ -> ok
+          end,
+  1    = 'clojerl.Agent':restart(Agent, 1, false),
+
+  ct:comment("Send failing action with a valid one after that"),
+  SleepFail = fun(_) -> timer:sleep(100), throw(foo) end,
+  Agent = 'clojerl.Agent':dispatch(Agent, SleepFail, []),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun(X) -> X + 1 end, []),
+  _     = sync(Agent, 0),
+  true  = 'clojerl.Agent':error(Agent) =/= ?NIL,
+
+  ct:comment("After restarting pending action is applied"),
+  1    = 'clojerl.Agent':restart(Agent, 1, false),
+  _    = sync(Agent, 0),
+  2    = 'clojerl.Agent':deref(Agent),
+
+  ct:comment("Send failing action with a valid one after that"),
+  Agent = 'clojerl.Agent':dispatch(Agent, SleepFail, []),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun(X) -> X + 1 end, []),
+  _     = sync(Agent, 0),
+  true  = 'clojerl.Agent':error(Agent) =/= ?NIL,
+
+  ct:comment("Restart pending action, clearing actions"),
+  1    = 'clojerl.Agent':restart(Agent, 1, true),
+  _    = sync(Agent, 0),
+
+  ct:comment("Value is unchanged"),
+  1    = 'clojerl.Agent':deref(Agent),
+
+  {comments, ""}.
+
+-spec release_pending(config()) -> result().
+release_pending(_Config) ->
+  ct:comment("Release pending from outside action returns 0"),
+  0 = 'clojerl.Agent':release_pending_sends(),
+
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  ct:comment("Loose pending sendings when action fails"),
+  Fail  = fun(_) ->
+              'clojerl.Agent':dispatch(Agent, fun(X) -> X + 1 end, []),
+              throw(foo)
+          end,
+  Agent = 'clojerl.Agent':dispatch(Agent, Fail, []),
+  ok    = sync(Agent, 1000),
+
+  ct:comment("Release actions before when action fails"),
+  Release = fun(_) ->
+                'clojerl.Agent':dispatch(Agent, fun(X) -> X + 1 end, []),
+                'clojerl.Agent':release_pending_sends(),
+                throw(foo)
+            end,
+  Agent   = 'clojerl.Agent':dispatch(Agent, Release, []),
+  ok      = sync(Agent, 1000),
+  2       = 'clojerl.Agent':deref(Agent),
+
+  {comments, ""}.
+
+-spec str(config()) -> result().
+str(_Config) ->
+  Agent0 = 'clojerl.Agent':?CONSTRUCTOR(1),
+  Agent1 = clj_rt:with_meta(Agent0, #{a => 1}),
+
+  <<"#<clojerl.Agent ", _/binary>> = clj_rt:str(Agent1),
+
+  {comments, ""}.
+
+-spec validator(config()) -> result().
+validator(_Config) ->
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+  fail  = 'clojerl.Agent':error_mode(Agent, fail),
+
+  ct:comment("Valid state is less than 3"),
+  Valid = fun(X) -> X < 3 end,
+  Valid = 'clojerl.Agent':validator(Agent, Valid),
+  Valid = 'clojerl.Agent':validator(Agent),
+
+  ct:comment("Change to a valid state"),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun erlang:'+'/2, [1]),
+  ok    = sync(Agent, 1000),
+  2     = clj_rt:deref(Agent),
+  ?NIL  = 'clojerl.Agent':error(Agent),
+
+  ct:comment("Change to an invalid state"),
+  Inc   = fun(X) -> X + 1 end,
+  ok    = sync(Agent, 1000, Inc),
+  2     = clj_rt:deref(Agent),
+  fail  = 'clojerl.Agent':error_mode(Agent),
+  true  = 'clojerl.Agent':error(Agent) =/= ?NIL,
+
+  ct:comment("Dispatch when agent is failed"),
+  ok    = try 'clojerl.Agent':dispatch(Agent, Inc, []), error
+          catch _:_ -> ok
+          end,
+
+  {comments, ""}.
+
+-spec complete_coverage(config()) -> result().
+complete_coverage(_Config) ->
+  Agent = 'clojerl.Agent':?CONSTRUCTOR(1),
+
+  Hash = 'clojerl.IHash':hash(Agent),
+  Hash = 'clojerl.IHash':hash(Agent),
+  true = erlang:is_integer(Hash),
+
+  %% clojerl.Agent
+  {noreply, state} = 'clojerl.Agent':handle_info(msg, state),
+  {ok, state}      = 'clojerl.Agent':terminate(msg, state),
+  {ok, state}      = 'clojerl.Agent':code_change(msg, from, state),
+
+  %% clojerl.Agent.Server
+  {noreply, state} = 'clojerl.Agent.Server':handle_cast(msg, state),
+  {noreply, state} = 'clojerl.Agent.Server':handle_info(msg, state),
+  {ok, state}      = 'clojerl.Agent.Server':terminate(msg, state),
+  {ok, state}      = 'clojerl.Agent.Server':code_change(msg, from, state),
+
+  {error, _}       = 'clojerl.Agent.Server':create(1, <<"id">>, 1),
+
+  {comments, ""}.
+
+%%------------------------------------------------------------------------------
+%% Helper functions
+%%------------------------------------------------------------------------------
+
+-spec sync('clojerl.Agent':type(), timeout()) -> ok | timeout.
+sync(Agent, Timeout) ->
+  sync(Agent, Timeout, fun(X) -> X end).
+
+-spec sync('clojerl.Agent':type(), timeout(), function()) -> ok | timeout.
+sync(Agent, Timeout, Fun) ->
+  Self  = erlang:self(),
+  Ref   = erlang:make_ref(),
+  Agent = 'clojerl.Agent':dispatch(Agent, fun(X) -> Self ! Ref, Fun(X) end, []),
+  Reply = clj_test_utils:wait_for(Ref, Timeout),
+
+  %% This will send a synchronous message to the agent which
+  %% will ensure any previous proceessing is done by the time
+  %% we return from this function
+  ErrorMode = 'clojerl.Agent':error_mode(Agent),
+  ErrorMode = 'clojerl.Agent':error_mode(Agent, ErrorMode),
+
+  Reply.

--- a/test/clojerl_Atom_SUITE.erl
+++ b/test/clojerl_Atom_SUITE.erl
@@ -93,7 +93,6 @@ reset(_Config) ->
 
   {comments, ""}.
 
-
 -spec compare_and_set(config()) -> result().
 compare_and_set(_Config) ->
   Atom = 'clojerl.Atom':?CONSTRUCTOR(2),


### PR DESCRIPTION
### Description

Implements the agent abstraction. Watches are missing, but they will be added with #689.

There is currently no plan to implement Refs so this PR removes Refs functions from `clojure.core`.

Related to #117.