### PR TITLE
[#684] Use name of shadowed local in pattern matching

### DIFF
--- a/scripts/examples/case.clje
+++ b/scripts/examples/case.clje
@@ -56,3 +56,30 @@
 
 (assert-with-tags (erlang/=:= (multiple-locals-not-ordered 1 1)
                               #erl[:five 5]))
+
+(def two-bindings-same-name-in-let
+  (fn* []
+       (let* [x 1
+              x 2
+              y 1]
+         (case* y
+                x :x-is-one
+                :x-is-two))))
+
+(assert-with-tags
+ (erlang/=:= (two-bindings-same-name-in-let)
+             :x-is-two))
+
+(def three-bindings-same-name-in-let
+  (fn* []
+       (let* [x 1
+              x 2
+              x 3
+              y 1]
+         (case* y
+                x :x-is-one
+                :x-is-three))))
+
+(assert-with-tags
+ (erlang/=:= (three-bindings-same-name-in-let)
+             :x-is-three))

--- a/src/erl/clojerl_expr.hrl
+++ b/src/erl/clojerl_expr.hrl
@@ -24,6 +24,7 @@
                            , shadow     => any()
                            , underscore => boolean()
                            , id         => integer()
+                           , binding    => boolean()
                            }.
 
 -type binding_expr()   :: #{ op          => binding


### PR DESCRIPTION
### Description

Correctly pattern match when multiple bindings have the same name.

Related #684 