### PR TITLE
[#699] Create clje.user on init

### DIFF
--- a/bootstrap/clojure.core.erl
+++ b/bootstrap/clojure.core.erl
@@ -24,11 +24,17 @@
                              , ns_atom   => 'clojure.core'
                              , name_atom => 'in-ns'
                              , val_atom  => 'in-ns__val'
-                             , meta      => #{ 'variadic?'     => false
-                                             , max_fixed_arity => 1
-                                             , fixed_arities   => [1]
-                                             , variadic_arity  => ?NIL
-                                             }
+                             , meta      =>
+                                 #{ 'variadic?'     => false
+                                  , max_fixed_arity => 1
+                                  , fixed_arities   => [1]
+                                  , variadic_arity  => ?NIL
+                                  , doc             => <<"Sets *ns* to the"
+                                                         "namespace named by"
+                                                         "the symbol, creating"
+                                                         "it if needed.">>
+                                  , added           => <<"1.0">>
+                                  }
                              }
            , <<"*ns*">>  => #{ ?TYPE     => 'clojerl.Var'
                              , ns        => <<"clojure.core">>
@@ -36,11 +42,12 @@
                              , ns_atom   => 'clojure.core'
                              , name_atom => '*ns*'
                              , val_atom  => '*ns*__val'
-                             , meta      => #{ dynamic => true
-                                             , tag => #{ ?TYPE => 'erlang.Type'
-                                                       , name  => 'clojerl.Namespace'
-                                                       }
-                                             }
+                             , meta      =>
+                                 #{ dynamic => true
+                                  , tag => #{ ?TYPE => 'erlang.Type'
+                                            , name  => 'clojerl.Namespace'
+                                            }
+                                  }
                              }
 
            , <<"*compile-path*">> =>
@@ -78,7 +85,14 @@
                 , ns_atom   => 'clojure.core'
                 , name_atom => '*agent*'
                 , val_atom  => '*agent*__val'
-                , meta      => #{dynamic => true}
+                , meta      => #{ dynamic => true
+                                , doc => <<"The agent currently running an "
+                                           "action on this thread, else nil">>
+                                , tag => #{ ?TYPE => 'erlang.Type'
+                                          , name  => 'clojerl.Agent'
+                                          }
+                                , added           => <<"1.0">>
+                                }
                 }
            , <<"*assert*">> =>
                #{ ?TYPE     => 'clojerl.Var'

--- a/src/clj/clojure/core.clje
+++ b/src/clj/clojure/core.clje
@@ -3139,8 +3139,7 @@
   stream/file"
   {:added "1.0"}
   [rdr]
-  (throw "unimplemented reader")
-  #_(. clojure.lang.Compiler (load rdr)))
+  (clj_compiler/load rdr))
 
 (defn load-string
   "Sequentially read and evaluate the set of forms contained in the

--- a/src/clj/clojure/main.clje
+++ b/src/clj/clojure/main.clje
@@ -9,7 +9,7 @@
 ;; Originally contributed by Stephen C. Gilardi
 
 (ns ^{:doc "Top-level main function for Clojure REPL and scripts."
-      :author "Stephen C. Gilardi and Rich Hickey"}
+       :author "Stephen C. Gilardi and Rich Hickey"}
   clojure.main
   (:refer-clojure :exclude [with-bindings]))
 
@@ -311,7 +311,7 @@ by default when a new command-line REPL is started."} repl-requires
 (defn- initialize
   "Common initialize routine for repl, script, and null opts"
   [args inits]
-  (ns 'clje.user)
+  (in-ns 'clje.user)
   (set! *command-line-args* args)
   (doseq [[opt arg] inits]
     ((init-dispatch opt) arg)))
@@ -329,7 +329,7 @@ by default when a new command-line REPL is started."} repl-requires
   present"
   [[_ & args] inits]
   (when-not (some #(= eval-opt (init-dispatch (first %))) inits)
-    (println "Clojure"  (clojure-version)))
+    (println "Clojure" (clojure-version)))
   (repl :init (fn []
                 (initialize args inits)
                 (apply require repl-requires)))

--- a/src/clj/clojure/pprint/dispatch.clje
+++ b/src/clj/clojure/pprint/dispatch.clje
@@ -17,7 +17,7 @@
 
 (in-ns 'clojure.pprint)
 
-(defmacro use-method
+(defmacro ^:private use-method
   "Installs a function as a new method of multimethod associated with dispatch-value. "
   [multifn dispatch-val func]
   `(clojerl.MultiFn/add_method (var ~multifn) ~dispatch-val (var ~func)))

--- a/src/clj/clojure/pprint/utilities.clje
+++ b/src/clj/clojure/pprint/utilities.clje
@@ -106,7 +106,7 @@ beginning of aseq"
 (defprotocol PrettyFlush
   (ppflush [_]))
 
-(defn char-code
+(defn- char-code
   "Convert char to int"
   [c]
   (cond

--- a/src/erl/clj_compiler.erl
+++ b/src/erl/clj_compiler.erl
@@ -9,6 +9,7 @@
         , compile_file/2
         , compile/1
         , compile/2
+        , load/1
         , load_file/1
         , load_string/1
         , eval/1
@@ -116,14 +117,22 @@ compile(Src) when is_binary(Src) ->
 compile(Src, Opts) when is_binary(Src) ->
   compile(Src, Opts, clj_env:default()).
 
--spec load_string(binary()) -> any().
-load_string(Path) ->
-  Env = compile(Path),
+-spec load('erlang.io.PushbackReader':type()) -> any().
+load(PushbackReader) ->
+  Opts        = default_options(),
+  ReaderOpts0 = maps:get(reader_opts, Opts),
+  ReaderOpts1 = ReaderOpts0#{?OPT_IO_READER => PushbackReader},
+  Env         = compile(<<>>, Opts#{reader_opts => ReaderOpts1}),
   clj_env:get(eval, Env).
 
 -spec load_file(binary()) -> any().
 load_file(Path) ->
   Env = compile_file(Path, default_options(), clj_env:default(), env),
+  clj_env:get(eval, Env).
+
+-spec load_string(binary()) -> any().
+load_string(Src) ->
+  Env = compile(Src),
   clj_env:get(eval, Env).
 
 -spec timed_compile(binary(), options(), clj_env:env()) ->

--- a/src/erl/clj_rt.erl
+++ b/src/erl/clj_rt.erl
@@ -5,6 +5,7 @@
 
 -export([ type/1, type_module/1
         , load/1, load/2
+        , load_script/2
         , count/1, nth/2, nth/3
         , 'empty?'/1, empty/1
         , seq/1, seq_or_else/1, to_list/1
@@ -86,6 +87,22 @@ load(ScriptBase, FailIfNotFound) ->
                      );
         FullFilePath -> clj_compiler:compile_file(FullFilePath)
       end
+  end,
+  ?NIL.
+
+-spec load_script(binary(), boolean()) -> any().
+load_script(ScriptName, FailIfNotFound) ->
+  File = filename:basename(ScriptName),
+  Ext  = filename:extension(File),
+  Name = filename:basename(File, Ext),
+  case resolve_file(Name, [Ext]) of
+    ?NIL ->
+      ?ERROR_WHEN( FailIfNotFound
+                 , [ <<"Could not locate Clojure resource on code path: ">>
+                   , ScriptName
+                   ]
+                 );
+    FullFilePath -> clj_compiler:load_file(FullFilePath)
   end,
   ?NIL.
 

--- a/src/erl/clj_utils.erl
+++ b/src/erl/clj_utils.erl
@@ -16,6 +16,8 @@
 
         , compare/2
 
+        , env_vars/0
+
         , format_error/2
         , error_str/2
 
@@ -222,6 +224,17 @@ compare(X, Y) ->
     X == Y -> 0;
     X >  Y -> 1
   end.
+
+-spec env_vars() -> #{binary() => binary()}.
+env_vars() ->
+  Pairs = [ begin
+              EntryBin = unicode:characters_to_binary(Entry),
+              [K, V]   = binary:split(EntryBin, <<"=">>),
+              {K, V}
+            end
+            || Entry <- os:getenv()
+          ],
+  maps:from_list(Pairs).
 
 -spec format_error(any(), clj_reader:location() | ?NIL) -> binary().
 format_error(List, Location) when is_list(List) ->

--- a/test/clj/clojure/test_clojure/metadata.clje
+++ b/test/clj/clojure/test_clojure/metadata.clje
@@ -15,16 +15,17 @@
 
 (def public-namespaces
   '[clojure.core
-    ;; clojure.pprint
+    clojure.pprint
     ;; clojure.inspector
     clojure.set
     clojure.stacktrace
     clojure.test
     clojure.walk
-    ;; clojure.xml
+    clojure.xml
     clojure.zip
+    clojure.erlang.io
     clojure.string
-    ;; clojure.data
+    clojure.data
     ])
 
 (doseq [ns public-namespaces]
@@ -37,7 +38,7 @@
   (into [] (filter (comp :doc meta) public-vars)))
 
 (def public-vars-with-docstrings-not-generated
-  (into [] (remove #(re-find #"^->[A-Z]" (name %)) public-vars-with-docstrings)))
+  (into [] (remove #(re-find #"^(map)?->[A-Za-z]" (name %)) public-vars-with-docstrings)))
 
 (deftest public-vars-with-docstrings-have-added
   (is (= [] (remove (comp :added meta) public-vars-with-docstrings-not-generated))))


### PR DESCRIPTION
### Description

- Create clje.user on application initialization.
- Load `user.clje` script if it is present in the code path.
- Start socket REPL servers of there are any `clojure.server.*` environment variables defined.

Fixes #609