### PR TITLE
[#681] Clojerl API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test-ct: clean
 
 test-clj: clean
 	${V} ${REBAR3} clojerl test
+	${V} echo
+	${V} echo "Running test.generative tests..."
+	${V} echo
+	${V} scripts/run-test-generative test/clj
 
 test: test-ct test-clj
 

--- a/bin/clojerl
+++ b/bin/clojerl
@@ -41,6 +41,7 @@ SELF=$(readlink_f "$0")
 CLJE_BINDIR=$(dirname "$SELF")
 CLJE_ROOT=$(dirname "$CLJE_BINDIR")
 
+CODE_PATHS=0
 ERL_ARGS="$ERL_ARGS -s clojerl_cli start +pc unicode -noshell"
 
 while [ "$#" -gt 0 ]
@@ -49,15 +50,31 @@ do
 
     case $key in
         -pa)
+            CODE_PATHS=1
             ERL_ARGS="$ERL_ARGS -pa $2"
             shift # past argument
             ;;
         -pz)
+            CODE_PATHS=0
             ERL_ARGS="$ERL_ARGS -pz $2"
             shift # past argument
             ;;
         *)
-            break;
+            # check if first char is dash
+            first_char=${key:0:1}
+            case $first_char in
+                -)
+                    break;
+                    ;;
+                *)
+                    # when it's not - maybe collect code paths
+                    if [ "$CODE_PATHS" -eq "1" ]; then
+                        ERL_ARGS="$ERL_ARGS $1";
+                    else
+                        break;
+                    fi
+                    ;;
+            esac
             ;;
     esac
     shift # past argument or value

--- a/scripts/run-test-generative
+++ b/scripts/run-test-generative
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-bin/clojerl -pa test/clj _build/*/lib/*/ebin \
-            -m clojure.test.generative.runner $1
+bash bin/clojerl \
+     -pa test/clj _build/*/lib/*/ebin \
+     -m clojure.test.generative.runner $1

--- a/scripts/run-test-generative
+++ b/scripts/run-test-generative
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-bin/clje -pa test/clj _build/*/lib/*/ebin \
-         -m clojure.test.generative.runner test
+bin/clojerl -pa test/clj _build/*/lib/*/ebin \
+            -m clojure.test.generative.runner $1

--- a/scripts/run-test-generative
+++ b/scripts/run-test-generative
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bin/clje -pa test/clj _build/*/lib/*/ebin \
+         -m clojure.test.generative.runner test

--- a/src/clj/clojure/core.clje
+++ b/src/clj/clojure/core.clje
@@ -9,7 +9,7 @@
 (ns clojure.core)
 
 ;; Unstick clojerl directory when bootstrapping.
-(clojerl/unstick)
+(clojerl_app/unstick)
 
 (def
   ^{:arglists '([& items])

--- a/src/clj/clojure/core.clje
+++ b/src/clj/clojure/core.clje
@@ -4109,8 +4109,7 @@
    See http://clojure.org/data_structures#hash for full algorithms."
   {:added "1.6"}
   [hash-basis count]
-  (throw "unimplemented hash")
-  #_(clojure.lang.Murmur3/mixCollHash hash-basis count))
+  (clj_murmur3/mix_coll_hash hash-basis count))
 
 (defn hash-ordered-coll
   "Returns the hash code, consistent with =, for an external ordered

--- a/src/clj/clojure/instant.clje
+++ b/src/clj/clojure/instant.clje
@@ -182,7 +182,7 @@ this var as the value for the 'inst key. The timezone offset will be used
 
 (in-ns 'clojure.core)
 
-(clojerl/unstick)
+(clojerl_app/unstick)
 
 (defn- print-date
   "Print a java.util.Date as RFC3339 timestamp, always in UTC.

--- a/src/clj/clojure/uuid.clje
+++ b/src/clj/clojure/uuid.clje
@@ -17,7 +17,7 @@
 
 (in-ns 'clojure.core)
 
-(clojerl/unstick)
+(clojerl_app/unstick)
 
 (defmethod print-method erlang.util.UUID [uuid ^erlang.io.IWriter w]
   (.write w (str "#uuid \"" (str uuid) "\"")))

--- a/src/clojerl.app.src
+++ b/src/clojerl.app.src
@@ -2,7 +2,7 @@
 , [ {description, "Clojure for the Erlang VM"}
   , {vsn, git}
   , {applications, [kernel, stdlib, compiler]}
-  , {mod, {clojerl, []}}
+  , {mod, {clojerl_app, []}}
   , {modules, []}
   , {registered, []}
   , {licenses, ["EPL v1.0"]}

--- a/src/erl/clj_murmur3.erl
+++ b/src/erl/clj_murmur3.erl
@@ -2,6 +2,7 @@
 
 -export([ ordered/1
         , unordered/1
+        , mix_coll_hash/2
         ]).
 
 -define(SEED, 0).
@@ -19,37 +20,37 @@
 ordered(Seq) ->
   List = clj_rt:to_list(Seq),
   Hashes = [clj_rt:hash(X) || X <- List],
-  murmur_ordered_coll(Hashes).
+  ordered_coll(Hashes).
 
 -spec unordered(any()) -> integer().
 unordered(Seq) ->
   List = clj_rt:to_list(Seq),
   Hashes = [clj_rt:hash(X) || X <- List],
-  murmur_unordered_coll(Hashes).
+  unordered_coll(Hashes).
 
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
 
-murmur_ordered_coll(Hashes) ->
-  Hash = do_murmur_ordered_coll(Hashes, 1),
-  murmur_mix_coll_hash(Hash, length(Hashes)).
+ordered_coll(Hashes) ->
+  Hash = do_ordered_coll(Hashes, 1),
+  mix_coll_hash(Hash, length(Hashes)).
 
-do_murmur_ordered_coll([], Hash) ->
+do_ordered_coll([], Hash) ->
   Hash;
-do_murmur_ordered_coll([H | Hashes], Hash) ->
-  do_murmur_ordered_coll(Hashes, ?UINT32(?UINT32(31 * Hash) + H)).
+do_ordered_coll([H | Hashes], Hash) ->
+  do_ordered_coll(Hashes, ?UINT32(?UINT32(31 * Hash) + H)).
 
-murmur_unordered_coll(Hashes) ->
-  Hash = do_murmur_unordered_coll(Hashes, 0) ,
-  murmur_mix_coll_hash(Hash, length(Hashes)).
+unordered_coll(Hashes) ->
+  Hash = do_unordered_coll(Hashes, 0) ,
+  mix_coll_hash(Hash, length(Hashes)).
 
-do_murmur_unordered_coll([], Hash) ->
+do_unordered_coll([], Hash) ->
   Hash;
-do_murmur_unordered_coll([H | Hashes], Hash) ->
-  do_murmur_unordered_coll(Hashes, ?UINT32(Hash + H)).
+do_unordered_coll([H | Hashes], Hash) ->
+  do_unordered_coll(Hashes, ?UINT32(Hash + H)).
 
-murmur_mix_coll_hash(Hash, Len) ->
+mix_coll_hash(Hash, Len) ->
   K1 = mix_k1(Hash),
   H1 = mix_h1(?SEED, K1),
   fmix(H1, Len).

--- a/src/erl/clojerl.erl
+++ b/src/erl/clojerl.erl
@@ -28,7 +28,9 @@ var(QualifiedName) ->
 
 -spec var(any(), any()) -> 'clojerl.Var':type().
 var(Ns, Name) ->
-  QualifiedSymbol = clj_rt:symbol(Ns, Name),
+  NsStr   = 'clojerl.Symbol':str(as_symbol(Ns)),
+  NameStr = 'clojerl.Symbol':str(as_symbol(Name)),
+  QualifiedSymbol = clj_rt:symbol(NsStr, NameStr),
   'clojerl.Var':find(QualifiedSymbol).
 
 %%==============================================================================

--- a/src/erl/clojerl.erl
+++ b/src/erl/clojerl.erl
@@ -1,10 +1,13 @@
 -module(clojerl).
 
--behavior(application).
+-include("clojerl.hrl").
+-include("clojerl_int.hrl").
 
--export([start/0, unstick/0]).
-
--export([start/2, stop/1]).
+-export([ start/0
+        , read/1
+        , var/1
+        , var/2
+        ]).
 
 -define(APP, clojerl).
 -define(STICKY_MODULES, ['clojure.core']).
@@ -14,67 +17,28 @@ start() ->
   {ok, _} = application:ensure_all_started(clojerl, permanent),
   ok.
 
--spec start(any(), any()) -> {ok, pid()} | {ok, pid(), any()} | {error, any()}.
-start(_Type, _Args) ->
-  {ok, _} = clojerl_sup:start_link(),
-  ok = stacktrace_depth(),
-  ok = io_options(),
-  ok = stick(),
-  ok = init(),
-  {ok, self()}.
+-spec read(binary()) -> any().
+read(Str) ->
+  'clojure.edn':'read-string'(Str).
 
--spec stop(any()) -> ok.
-stop(_State) -> ok.
+-spec var(any()) -> 'clojerl.Var':type().
+var(QualifiedName) ->
+  QualifiedSymbol = as_symbol(QualifiedName),
+  'clojerl.Var':find(QualifiedSymbol).
+
+-spec var(any(), any()) -> 'clojerl.Var':type().
+var(Ns, Name) ->
+  QualifiedSymbol = clj_rt:symbol(Ns, Name),
+  'clojerl.Var':find(QualifiedSymbol).
 
 %%==============================================================================
 %% Internal functions
 %%==============================================================================
 
--spec init() -> ok.
-init() ->
-  CljeUserSym = clj_rt:symbol(<<"clje.user">>),
-  'clojure.core':'in-ns'(CljeUserSym),
-  %% This will not be available during bootstrap
-  case erlang:function_exported('clojure.core', refer, 2) of
-    true ->
-      ClojureCoreSym = clj_rt:symbol(<<"clojure.core">>),
-      'clojure.core':'refer'(ClojureCoreSym, []),
-
-      %% Maybe load user.clje script
-      clj_rt:load_script(<<"user.clje">>, false),
-
-      ClojureCoreServerSym = clj_rt:symbol(<<"clojure.core.server">>),
-      'clojure.core':require([ClojureCoreServerSym]),
-      'clojure.core.server':'start-servers'(clj_utils:env_vars()),
-      ok;
-    false ->
-      ok
-  end.
-
--spec stacktrace_depth() -> ok.
-stacktrace_depth() ->
-  StacktraceDepth = application:get_env(?APP, backtrace_depth, 20),
-  erlang:system_flag(backtrace_depth, StacktraceDepth),
-  ok.
-
--spec io_options() -> ok.
-io_options() ->
-  %% Ensure encoding is unicode
-  IoOpts = [{binary, true}, {encoding, unicode}],
-  ok = io:setopts(IoOpts).
-
-%% Coverage analysis fails if the directory is sticky
--ifdef(COVER).
--spec stick() -> ok.
-stick() -> ok.
--else.
--spec stick() -> ok.
-stick() ->
-  [code:stick_mod(M) || M <- ?STICKY_MODULES],
-  ok.
--endif.
-
--spec unstick() -> ok.
-unstick() ->
-  [code:unstick_mod(M) || M <- ?STICKY_MODULES],
-  ok.
+-spec as_symbol(binary() | 'clojerl.Symbol':type()) ->
+  'clojerl.Symbol':type().
+as_symbol(X) when is_binary(X) ->
+  'clojerl.Symbol':?CONSTRUCTOR(X);
+as_symbol(X) ->
+  ?ERROR_WHEN(not clj_rt:'symbol?'(X), [<<"Invalid symbol ">>, X]),
+  X.

--- a/src/erl/clojerl_app.erl
+++ b/src/erl/clojerl_app.erl
@@ -1,0 +1,75 @@
+-module(clojerl_app).
+
+-behavior(application).
+
+-export([unstick/0]).
+
+-export([start/2, stop/1]).
+
+-define(APP, clojerl).
+-define(STICKY_MODULES, ['clojure.core']).
+
+-spec start(any(), any()) -> {ok, pid()} | {ok, pid(), any()} | {error, any()}.
+start(_Type, _Args) ->
+  {ok, _} = clojerl_sup:start_link(),
+  ok = stacktrace_depth(),
+  ok = io_options(),
+  ok = stick(),
+  ok = init(),
+  {ok, self()}.
+
+-spec stop(any()) -> ok.
+stop(_State) -> ok.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+
+-spec init() -> ok.
+init() ->
+  CljeUserSym = clj_rt:symbol(<<"clje.user">>),
+  'clojure.core':'in-ns'(CljeUserSym),
+  %% This will not be available during bootstrap
+  case erlang:function_exported('clojure.core', refer, 2) of
+    true ->
+      ClojureCoreSym = clj_rt:symbol(<<"clojure.core">>),
+      'clojure.core':'refer'(ClojureCoreSym, []),
+
+      %% Maybe load user.clje script
+      clj_rt:load_script(<<"user.clje">>, false),
+
+      ClojureCoreServerSym = clj_rt:symbol(<<"clojure.core.server">>),
+      'clojure.core':require([ClojureCoreServerSym]),
+      'clojure.core.server':'start-servers'(clj_utils:env_vars()),
+      ok;
+    false ->
+      ok
+  end.
+
+-spec stacktrace_depth() -> ok.
+stacktrace_depth() ->
+  StacktraceDepth = application:get_env(?APP, backtrace_depth, 20),
+  erlang:system_flag(backtrace_depth, StacktraceDepth),
+  ok.
+
+-spec io_options() -> ok.
+io_options() ->
+  %% Ensure encoding is unicode
+  IoOpts = [{binary, true}, {encoding, unicode}],
+  ok = io:setopts(IoOpts).
+
+%% Coverage analysis fails if the directory is sticky
+-ifdef(COVER).
+-spec stick() -> ok.
+stick() -> ok.
+-else.
+-spec stick() -> ok.
+stick() ->
+  [code:stick_mod(M) || M <- ?STICKY_MODULES],
+  ok.
+-endif.
+
+-spec unstick() -> ok.
+unstick() ->
+  [code:unstick_mod(M) || M <- ?STICKY_MODULES],
+  ok.

--- a/src/erl/erlang/erlang.io.File.erl
+++ b/src/erl/erlang/erlang.io.File.erl
@@ -87,13 +87,13 @@ read(File) ->
 read(#{?TYPE := ?M, pid := Pid}, Length) ->
   case io:get_chars(Pid, "", Length) of
     eof -> eof;
-    Str -> list_to_binary(Str)
+    Str -> unicode:characters_to_binary(Str)
   end.
 
 read_line(#{?TYPE := ?M, pid := Pid}) ->
   case io:request(Pid, {get_line, unicode, ""}) of
     eof -> eof;
-    Str -> list_to_binary(Str)
+    Str -> unicode:characters_to_binary(Str)
   end.
 
 skip(#{?TYPE := ?M}, _Length) ->

--- a/src/erl/erlang/erlang.io.File.erl
+++ b/src/erl/erlang/erlang.io.File.erl
@@ -7,7 +7,11 @@
 -behavior('erlang.io.IWriter').
 -behavior('clojerl.IStringable').
 
--export([open/1, open/2, path/1]).
+-export([ ?CONSTRUCTOR/1
+        , open/1
+        , open/2
+        , path/1
+        ]).
 -export([make_temp/2]).
 
 -export([close/1]).
@@ -26,6 +30,10 @@
                  , pid   => pid() | file:fd()
                  , path  => path()
                  }.
+
+-spec ?CONSTRUCTOR(path()) -> type().
+?CONSTRUCTOR(Path) ->
+  open(Path).
 
 -spec open(path()) -> type().
 open(Path) when is_binary(Path) ->

--- a/test/clj/clojure/test_clojure/api.clje
+++ b/test/clj/clojure/test_clojure/api.clje
@@ -1,0 +1,54 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.test-clojure.api
+  (:require [clojure.test.generative :refer (defspec)]
+            [clojure.test-clojure.generators :as cgen])
+  (:import clojure.lang.IFn
+           clojure.java.api.Clojure
+           clojure.lang.Var))
+
+(set! *warn-on-reflection* true)
+
+(defn roundtrip
+  "Print an object and read it back with Clojure/read"
+  [o]
+  (binding [*print-length* nil
+            *print-dup* nil
+            *print-level* nil]
+    (Clojure/read (pr-str o))))
+
+(defn api-var-str
+  [^Var v]
+  (Clojure/var (str (.name (.ns v)))
+               (str (.sym v))))
+
+(defn api-var
+  [^Var v]
+  (Clojure/var (.name (.ns v))
+               (.sym v)))
+
+(defspec api-can-read
+  roundtrip
+  [^{:tag cgen/ednable} o]
+  (when-not (= o %)
+    (throw (ex-info "Value cannot roundtrip with Clojure/read" {:printed o :read %}))))
+
+(defspec api-can-find-var
+  api-var
+  [^{:tag cgen/var} v]
+  (when-not (= v %)
+    (throw (ex-info "Var cannot roundtrip through Clojure/var" {:from v :to %}))))
+
+(defspec api-can-find-var-str
+  api-var-str
+  [^{:tag cgen/var} v]
+  (when-not (= v %)
+    (throw (ex-info "Var cannot roundtrip strings through Clojure/var" {:from v :to %}))))
+
+

--- a/test/clj/clojure/test_clojure/api.clje
+++ b/test/clj/clojure/test_clojure/api.clje
@@ -9,11 +9,9 @@
 (ns clojure.test-clojure.api
   (:require [clojure.test.generative :refer (defspec)]
             [clojure.test-clojure.generators :as cgen])
-  (:import clojure.lang.IFn
-           clojure.java.api.Clojure
-           clojure.lang.Var))
+  (:import clojerl.Var))
 
-(set! *warn-on-reflection* true)
+;; (set! *warn-on-infer* true)
 
 (defn roundtrip
   "Print an object and read it back with Clojure/read"
@@ -21,17 +19,17 @@
   (binding [*print-length* nil
             *print-dup* nil
             *print-level* nil]
-    (Clojure/read (pr-str o))))
+    (clojerl/read (pr-str o))))
 
 (defn api-var-str
   [^Var v]
-  (Clojure/var (str (.name (.ns v)))
-               (str (.sym v))))
+  (clojerl/var (.namespace v)
+               (.name v)))
 
 (defn api-var
   [^Var v]
-  (Clojure/var (.name (.ns v))
-               (.sym v)))
+  (clojerl/var (symbol (.namespace v))
+               (symbol (.name v))))
 
 (defspec api-can-read
   roundtrip
@@ -50,5 +48,3 @@
   [^{:tag cgen/var} v]
   (when-not (= v %)
     (throw (ex-info "Var cannot roundtrip strings through Clojure/var" {:from v :to %}))))
-
-

--- a/test/clj/clojure/test_clojure/numbers.clje
+++ b/test/clj/clojure/test_clojure/numbers.clje
@@ -455,45 +455,45 @@ Math/pow overflows to Infinity."
   []
   (gen/one-of #(gen/uniform -1 32) gen/byte gen/int))
 
-#_((defspec integer-commutative-laws
-     (partial map identity)
-     [^{:tag 'clojure.test-clojure.numbers/integer} a
-      ^{:tag 'clojure.test-clojure.numbers/integer} b]
-     (assert (= (+ a b) (+ b a)))
-     (assert (= (* a b) (* b a))))
+(defspec integer-commutative-laws
+  (partial map identity)
+  [^{:tag clojure.test-clojure.numbers/integer} a
+   ^{:tag clojure.test-clojure.numbers/integer} b]
+  (assert (= (+ a b) (+ b a)))
+  (assert (= (* a b) (* b a))))
 
-   (defspec integer-associative-laws
-     (partial map identity)
-     [^{:tag 'clojure.test-clojure.numbers/integer} a
-      ^{:tag 'clojure.test-clojure.numbers/integer} b
-      ^{:tag 'clojure.test-clojure.numbers/integer} c]
-     (assert (= (+ (+ a b) c) (+ a (+ b c))))
-     (assert (= (* (* a b) c) (* a (* b c)))))
+(defspec integer-associative-laws
+  (partial map identity)
+  [^{:tag clojure.test-clojure.numbers/integer} a
+   ^{:tag clojure.test-clojure.numbers/integer} b
+   ^{:tag clojure.test-clojure.numbers/integer} c]
+  (assert (= (+ (+ a b) c) (+ a (+ b c))))
+  (assert (= (* (* a b) c) (* a (* b c)))))
 
-   (defspec integer-distributive-laws
-     (partial map identity)
-     [^{:tag 'clojure.test-clojure.numbers/integer} a
-      ^{:tag 'clojure.test-clojure.numbers/integer} b
-      ^{:tag 'clojure.test-clojure.numbers/integer} c]
-     (assert (= (* a (+ b c)) (+ (* a b) (* a c)))))
+(defspec integer-distributive-laws
+  (partial map identity)
+  [^{:tag clojure.test-clojure.numbers/integer} a
+   ^{:tag clojure.test-clojure.numbers/integer} b
+   ^{:tag clojure.test-clojure.numbers/integer} c]
+  (assert (= (* a (+ b c)) (+ (* a b) (* a c)))))
 
-   (defspec addition-undoes-subtraction
-     (partial map identity)
-     [^{:tag 'clojure.test-clojure.numbers/integer} a
-      ^{:tag 'clojure.test-clojure.numbers/integer} b]
-     (assert (= a
-                (-> a (- b) (+ b)))))
+(defspec addition-undoes-subtraction
+  (partial map identity)
+  [^{:tag clojure.test-clojure.numbers/integer} a
+   ^{:tag clojure.test-clojure.numbers/integer} b]
+  (assert (= a
+             (-> a (- b) (+ b)))))
 
-   (defspec quotient-and-remainder
-     (fn [a b] (sort [a b]))
-     [^{:tag 'clojure.test-clojure.numbers/integer} a
-      ^{:tag 'clojure.test-clojure.numbers/integer} b]
-     (when-not (zero? (second %))
-       (let [[a d] %
-             q (quot a d)
-             r (rem a d)]
-         (assert (= a
-                    (+ (* q d) r)))))))
+(defspec quotient-and-remainder
+  (fn [a b] (sort [a b]))
+  [^{:tag clojure.test-clojure.numbers/integer} a
+   ^{:tag clojure.test-clojure.numbers/integer} b]
+  (when-not (zero? (second %))
+    (let [[a d] %
+          q (quot a d)
+          r (rem a d)]
+      (assert (= a
+                 (+ (* q d) r))))))
 
 (deftest comparisons
   (let [small-numbers [1 1.0 (int 1) (float 1.0) 1N 1M]

--- a/test/clj/clojure/test_clojure/reader.cljc
+++ b/test/clj/clojure/test_clojure/reader.cljc
@@ -16,10 +16,6 @@
 ;;  scgilardi (gmail)
 ;;  Created 22 October 2008
 
-;; Ensure there is a clje.user namespace
-(ns clje.user)
-(def x 1)
-
 (ns clojure.test-clojure.reader
   (:use clojure.test)
   (:use [clojure.instant :only [read-instant-date


### PR DESCRIPTION
### Description

- Exposes equivalent functions as the ones in `clojure.java.api.Clojure`.
- Enables the running of test.generative tests, which weren't being run.

Fixes #681 