### PR TITLE
Add Dockerfile and publish the official Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ what [features][features] does it include and
 To try it out and get a sense of what you can do, you can visit
 [Try Clojerl][try-clojerl].
 
+## Docker REPL
+
+To quickly try out `clojerl` via docker you could make use of docker image like so 
+
+```
+docker pull clojerl/clojerl
+docker run -it clojerl/clojerl
+
+```
+And you should be able to see the prompt 
+
+```clojure
+
+ Clojure 0.0.0-974.592ad8a
+ clje.user=>
+
+```
+
+
 ### Local REPL
 
 Running `make repl` (on Windows `bin/clje.bat`) will start the REPL

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ To quickly try out `clojerl` via docker you could make use of docker image like 
 ```
 docker pull clojerl/clojerl
 docker run -it clojerl/clojerl
-
 ```
 And you should be able to see the prompt 
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,6 +1,11 @@
 FROM erlang:latest
 
-RUN git clone https://github.com/clojerl/clojerl &&  cd clojerl && make 
+RUN git clone https://github.com/clojerl/clojerl && \
+        cd clojerl                               && \
+        make                                     && \
+        apt-get update                           && \
+        apt-get install rlwrap                   && \
+        apt-get clean                            && \
+        apt-get autoclean
 
-CMD ["/clojerl/bin/clojerl"]
-
+CMD sleep 0.1; /clojerl/bin/clje

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,6 @@
+FROM erlang:latest
+
+RUN git clone https://github.com/clojerl/clojerl &&  cd clojerl && make 
+
+CMD ["/clojerl/bin/clojerl"]
+

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:latest
+FROM erlang:22.2.3
 
 RUN git clone https://github.com/clojerl/clojerl && \
         cd clojerl                               && \


### PR DESCRIPTION
Hi @jfacorro ,

I've been following the project for a while now and I thought that it might help to have a docker image ready for the quickly trying out the project. I noticed that you previously did make some initiative on `docker hub` here https://hub.docker.com/r/jfacorro/clojerl but it doesn't seem to be usable.

The `Dockerfile` I've added at the moment is quite basic and so, _I've only created a draft PR asI'm looking forward to adapting the PR as to how you see fit_.

I'd really like to see `official clojerl` docker image to be there on `docker hub`.