### PR TITLE
[#711] Stack shows wrong location for error

### DIFF
--- a/src/erl/clj_reader.erl
+++ b/src/erl/clj_reader.erl
@@ -660,13 +660,17 @@ expand_list(List, Result) ->
 
 -spec add_meta(any(), any()) -> any().
 add_meta(Form, Result) ->
-  case clj_rt:'meta?'(Form) of
-    true ->
-      WithMetaSym = clj_rt:symbol(<<"clojure.core">>, <<"with-meta">>),
-      Meta = syntax_quote(clj_rt:meta(Form)),
-      clj_rt:list([WithMetaSym, Result, Meta]);
-    _ ->
-      Result
+  case clj_rt:'meta?'(Form) andalso clj_rt:meta(Form) of
+    false  -> Result;
+    ?NIL   -> Result;
+    Meta0  ->
+      case remove_location(Meta0) of
+        ?NIL ->
+          Result;
+        _ ->
+          WithMetaSym = clj_rt:symbol(<<"clojure.core">>, <<"with-meta">>),
+          clj_rt:list([WithMetaSym, Result, syntax_quote(Meta0)])
+      end
   end.
 
 is_unquote(Form) ->

--- a/test/clj_test_utils.hrl
+++ b/test/clj_test_utils.hrl
@@ -1,2 +1,9 @@
 -type config() :: list().
 -type result() :: {comments, string()}.
+
+-define(assertEquiv(X, Y)
+       , case clj_rt:equiv(X, Y) of
+           true -> ok;
+           false -> ?ERROR([X, <<" is not equivalent to ">>, Y])
+         end
+       ).


### PR DESCRIPTION
### Description

There was a very subtle bug in the reader where location metadata information was always added to expressions expanded through syntax quote. The behaviour in both [`tools.reader`](https://github.com/clojure/tools.reader/blob/master/src/main/clojure/clojure/tools/reader.clj#L670) and [`clojure.lang.LispReader`](https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/LispReader.java#L1122) is that metadata is only added when it includes information other than location (e.g.`:line`, `:column`, etc). 

Fixes #711.