### PR TITLE
[#714] Improve map get performance

### DIFF
--- a/scripts/profile-function
+++ b/scripts/profile-function
@@ -59,7 +59,7 @@ fi
 ################################################################################
 
 # Fetch dev deps and compile
-rebar3 as dev do upgrade, compile
+rebar3 as dev do upgrade, clojerl compile
 
 # Generate args
 ARGS=$(echo "$@" | tr ' ' ,)
@@ -71,7 +71,7 @@ SVG_FILE="$TRACE_FILE_SORTED.svg"
 
 echo "Running eflame for $MODULE:$FUNCTION($ARGS)"
 
-PID=$(erl -sname eflame-expr -pa _build/*/lib/*/ebin -pa ebin -s clojerl -noshell \
+PID=$(erl -sname eflame-expr -pa _build/dev/lib/*/ebin -pa ebin -s clojerl -noshell \
           -eval "erlang:apply('$MODULE', '$FUNCTION', [$ARGS]), \
                  eflame:apply(normal_with_children, \"$TRACE_FILE\", '$MODULE', '$FUNCTION', [$ARGS]), \
                  io:format(\"~p~n\", [self()]), \

--- a/src/erl/lang/clojerl.Keyword.erl
+++ b/src/erl/lang/clojerl.Keyword.erl
@@ -85,7 +85,7 @@ apply(Keyword, Args) ->
 
 %% clojerl.IHash
 
-hash(Keyword) when is_atom(Keyword) ->
+hash(Keyword) ->
   erlang:phash2(Keyword).
 
 %% clojerl.INamed


### PR DESCRIPTION
Fixes #714 

### (Micro)Benchmark code

```
(simple-benchmark [coll {:foo 1 :bar 2}] (get coll :foo) 1000000)
(simple-benchmark [coll {'foo 1 'bar 2}] (get coll 'foo) 1000000)
(simple-benchmark [coll {:foo 1 :bar 2}] (:foo coll) 1000000)
(simple-benchmark [coll {'foo 1 'bar 2}] ('foo coll) 1000000)
(let [kw  :foo
      sym 'foo]
  (simple-benchmark [coll {:foo 1 :bar 2}] (kw coll) 1000000)
  (simple-benchmark [coll {'foo 1 'bar 2}] (sym coll) 1000000))
```

### Before

```
[coll {:foo 1, :bar 2}], (get coll :foo), 1000000 runs, 148 msecs
[coll {(quote foo) 1, (quote bar) 2}], (get coll (quote foo)), 1000000 runs, 202 msecs
[coll {:foo 1, :bar 2}], (:foo coll), 1000000 runs, 172 msecs
[coll {(quote foo) 1, (quote bar) 2}], ((quote foo) coll), 1000000 runs, 213 msecs
[coll {:foo 1, :bar 2}], (kw coll), 1000000 runs, 175 msecs
[coll {(quote foo) 1, (quote bar) 2}], (sym coll), 1000000 runs, 217 msecs
```

### After

```
[coll {:foo 1, :bar 2}], (get coll :foo), 1000000 runs, 112 msecs
[coll {(quote foo) 1, (quote bar) 2}], (get coll (quote foo)), 1000000 runs, 171 msecs
[coll {:foo 1, :bar 2}], (:foo coll), 1000000 runs, 142 msecs
[coll {(quote foo) 1, (quote bar) 2}], ((quote foo) coll), 1000000 runs, 192 msecs
[coll {:foo 1, :bar 2}], (kw coll), 1000000 runs, 140 msecs
[coll {(quote foo) 1, (quote bar) 2}], (sym coll), 1000000 runs, 191 msecs
```