### PR TITLE
[#310] Native code compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ install:
   - export PATH=$PWD:$PATH
 script:
   - make ci
+  - make clean compile-native
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ REBAR3    := rebar3
 RLWRAP    := $(shell type -p rlwrap &> /dev/null && echo rlwrap || echo)
 V         := @
 EXAMPLE   ?= *
+OTP       := $(shell erl -noshell -eval "io:format(erlang:system_info(otp_release))" -eval "erlang:halt()" || echo)
 
 .PHONY: all clojure test shell clean
 
@@ -15,6 +16,14 @@ all: compile
 
 compile:
 	${V} ${REBAR3} clojerl compile
+
+compile-native:
+	${V} if [[ ${OTP} =~ 2.+ ]]; then \
+		echo "Compiling to native..."; \
+		ERL_COMPILER_OPTIONS="native" ${REBAR3} clojerl compile; \
+	else \
+		echo "Compiling to native not supported for Erlang/OTP ${OTP}"; \
+	fi;
 
 test-ct: clean
 	${V} ${REBAR3} do ct --cover, cover

--- a/bin/clojerl
+++ b/bin/clojerl
@@ -11,7 +11,6 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
    -pz PATH            Adds PATH to the end of the code path
    -o PATH             Specify output directory for compiled files
    -t, --time          Print the time spent on compiling
-   -vv, --verbose      Verbose compiling
    --to-core FILE      Output the Core Erlang representation to FILE
    FILES               List of .clje files
 

--- a/bin/clojerl.bat
+++ b/bin/clojerl.bat
@@ -16,7 +16,6 @@ echo    -pa PATH            Adds PATH to the beginning of the code path
 echo    -pz PATH            Adds PATH to the end of the code path
 echo    -o PATH             Specify output directory for compiled files
 echo    -t, --time          Print the time spent on compiling
-echo    -vv, --verbose      Verbose compiling
 echo    --to-core FILE      Output the Core Erlang representation to FILE
 echo    FILES               List of .clje files
 echo.
@@ -54,7 +53,7 @@ rem Parse parameters
 :startloop
 set par=%1
 shift
-rem When there are no more parameters 
+rem When there are no more parameters
 if "%par%"=="" (goto erl_libs)
 rem Process parameters
 if "%par%"==""--werl"" (set "useWerl=1" && goto startloop)

--- a/rebar.config
+++ b/rebar.config
@@ -44,7 +44,7 @@
 
 %% Plugins
 
-{plugins, [ rebar3_clojerl
+{plugins, [ {rebar3_clojerl, {git, "git://github.com/clojerl/rebar3_clojerl.git", {branch, "master"}}}
           ]}.
 
 { provider_hooks

--- a/src/clj/clojure/core.clje
+++ b/src/clj/clojure/core.clje
@@ -4582,10 +4582,10 @@
       (if load
         (try
           (load lib need-ns require)
-          (catch :error e :stack st
+          (catch :error e
             (when undefined-on-entry
               (remove-ns lib))
-            (throw e st)))
+            (throw e)))
         (throw-if (and need-ns (not (find-ns lib)))
                   "namespace '~s' not found" lib))
       (when (and need-ns *loading-verbosely*)

--- a/src/clj/clojure/main.clje
+++ b/src/clj/clojure/main.clje
@@ -281,7 +281,7 @@ by default when a new command-line REPL is started."} repl-requires
   "Loads Clojure source from a file or resource given its path. Paths
   beginning with @ or @/ are considered relative to codepath."
   [^clojerl.String path]
-  (clj_compiler/compile_file path))
+  (clj_compiler/load_file path))
 
 (defn- init-opt
   "Load a script"

--- a/src/erl/clj_compiler.erl
+++ b/src/erl/clj_compiler.erl
@@ -50,11 +50,7 @@
 
 -spec default_options() -> options().
 default_options() ->
-  #{ erl_flags   => [ verbose
-                    , nowarn_unused_vars
-                    , nowarn_shadow_vars
-                    , nowarn_unused_record
-                    ]
+  #{ erl_flags   => []
    , clj_flags   => []
    , verbose     => false
    , reader_opts => #{}

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -989,6 +989,8 @@ ast(#{op := 'try'} = Expr, State) ->
                               ],
   RaiseAst          = cerl:c_primop(cerl:c_atom(raise), [Z, Y]),
 
+  %% A last catch-call clause is mandatory for when none of the previous
+  %% catch clauses were matched.
   CatchAllClause    = cerl:ann_c_clause(Ann, CatchVarsAsts, RaiseAst),
   { ClausesVars
   , CaseAst
@@ -996,7 +998,7 @@ ast(#{op := 'try'} = Expr, State) ->
 
   {Finally, State2} = case FinallyExpr of
                         ?NIL -> {?NIL, State1};
-                        _         -> pop_ast(ast(FinallyExpr, State))
+                        _    -> pop_ast(ast(FinallyExpr, State))
                       end,
 
   VarAst = new_c_var(Ann),

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -228,7 +228,7 @@ ast(#{op := deftype} = Expr, State0) ->
                     ],
 
   %% Add this new type to the protocol
-  Opts = clj_env:get(compiler_opts, default_compiler_options(), Env),
+  Opts = clj_env:get(compiler_opts, #{}, Env),
   [ protocol_add_type(Module, ProtocolModule, Opts)
     || ProtocolModule <- ProtocolModules
   ],
@@ -325,7 +325,7 @@ ast(#{op := deftype} = Expr, State0) ->
   clj_module:add_exports(Exports, Module),
   clj_module:add_functions(Functions, Module),
 
-  Opts = clj_env:get(compiler_opts, default_compiler_options(), Env),
+  Opts = clj_env:get(compiler_opts, #{}, Env),
   clj_compiler:compile_module(clj_module:get_module(Module), Opts),
 
   Ast = cerl:ann_abstract(ann_from(Env), Name),
@@ -380,7 +380,7 @@ ast(#{op := defprotocol} = Expr, State) ->
   clj_module:add_functions(Functions1, Module),
   clj_module:add_exports(Exports, Module),
 
-  Opts = clj_env:get(compiler_opts, default_compiler_options(), Env),
+  Opts = clj_env:get(compiler_opts, #{}, Env),
   clj_compiler:compile_module(clj_module:get_module(Module), Opts),
 
   Ast = cerl:ann_abstract(Ann, NameSym),
@@ -420,10 +420,7 @@ ast(#{op := extend_type} = Expr, State) ->
         clj_module:add_exports(Exports, ImplModule),
         clj_module:add_functions(FunctionsAsts, ImplModule),
 
-        Opts       = clj_env:get( compiler_opts
-                                , default_compiler_options()
-                                , Env
-                                ),
+        Opts       = clj_env:get(compiler_opts, #{}, Env),
 
         clj_compiler:compile_module(clj_module:get_module(ImplModule), Opts),
         protocol_add_type(TypeModule, ImplModule, ProtoModule, Opts),
@@ -2236,10 +2233,6 @@ ann_from(Env) ->
 -spec to_atom('clojerl.Symbol':type()) -> atom().
 to_atom(Symbol) ->
   binary_to_atom('clojerl.Symbol':name(Symbol), utf8).
-
--spec default_compiler_options() -> clj_compiler:opts().
-default_compiler_options() ->
-  #{erl_flags => [binary, debug_info], output_dir => <<"ebin">>}.
 
 -spec new_c_var(cerl:ann()) -> cerl:c_var().
 new_c_var(Ann) ->

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -326,7 +326,7 @@ ast(#{op := deftype} = Expr, State0) ->
   clj_module:add_functions(Functions, Module),
 
   Opts = clj_env:get(compiler_opts, #{}, Env),
-  clj_compiler:compile_module(clj_module:get_module(Module), Opts),
+  clj_compiler:module(clj_module:get_module(Module), Opts),
 
   Ast = cerl:ann_abstract(ann_from(Env), Name),
 
@@ -381,7 +381,7 @@ ast(#{op := defprotocol} = Expr, State) ->
   clj_module:add_exports(Exports, Module),
 
   Opts = clj_env:get(compiler_opts, #{}, Env),
-  clj_compiler:compile_module(clj_module:get_module(Module), Opts),
+  clj_compiler:module(clj_module:get_module(Module), Opts),
 
   Ast = cerl:ann_abstract(Ann, NameSym),
   push_ast(Ast, State);
@@ -422,7 +422,7 @@ ast(#{op := extend_type} = Expr, State) ->
 
         Opts       = clj_env:get(compiler_opts, #{}, Env),
 
-        clj_compiler:compile_module(clj_module:get_module(ImplModule), Opts),
+        clj_compiler:module(clj_module:get_module(ImplModule), Opts),
         protocol_add_type(TypeModule, ImplModule, ProtoModule, Opts),
 
         StateAcc2
@@ -1473,7 +1473,7 @@ protocol_add_type(TypeModule, ImplModule, ProtocolModule, Opts) ->
                  || F <- Functions0
                ],
   clj_module:add_functions(Functions1, ProtocolModule),
-  clj_compiler:compile_module(clj_module:get_module(ProtocolModule), Opts),
+  clj_compiler:module(clj_module:get_module(ProtocolModule), Opts),
   ok.
 
 -spec protocol_function_add_type( { {atom(), arity()}

--- a/src/erl/clj_module.erl
+++ b/src/erl/clj_module.erl
@@ -523,7 +523,7 @@ build_fake_fun(Function, Arity, Module) ->
     Bindings    = #{<<"#'clojure.core/*compile-files*">> => false},
     ok          = 'clojerl.Var':push_bindings(Bindings),
     CompileOpts = #{fake => true},
-    clj_compiler:compile_module(FakeModule, CompileOpts)
+    clj_compiler:module(FakeModule, CompileOpts)
   after
     ok = 'clojerl.Var':pop_bindings()
   end,

--- a/src/erl/clj_module.erl
+++ b/src/erl/clj_module.erl
@@ -522,7 +522,7 @@ build_fake_fun(Function, Arity, Module) ->
   try
     Bindings    = #{<<"#'clojure.core/*compile-files*">> => false},
     ok          = 'clojerl.Var':push_bindings(Bindings),
-    CompileOpts = #{erl_flags => [from_core, binary], fake => true},
+    CompileOpts = #{fake => true},
     clj_compiler:compile_module(FakeModule, CompileOpts)
   after
     ok = 'clojerl.Var':pop_bindings()

--- a/src/erl/clj_multimethod.erl
+++ b/src/erl/clj_multimethod.erl
@@ -113,6 +113,6 @@ generate_dispatch_map(DispatchMapVar, Map) ->
   clj_module:add_exports([{ValName, 0}], Module),
 
   CljModule = clj_module:get_module(Module),
-  clj_compiler:compile_module(CljModule),
+  clj_compiler:module(CljModule),
 
   ok.

--- a/src/erl/clj_rt.erl
+++ b/src/erl/clj_rt.erl
@@ -85,7 +85,7 @@ load(ScriptBase, FailIfNotFound) ->
                        , <<" on code path.">>
                        ]
                      );
-        FullFilePath -> clj_compiler:compile_file(FullFilePath)
+        FullFilePath -> clj_compiler:file(FullFilePath)
       end
   end,
   ?NIL.

--- a/src/erl/clojerl_cli.erl
+++ b/src/erl/clojerl_cli.erl
@@ -27,7 +27,6 @@ default_options() ->
   #{ compile      => false
    , compile_path => "ebin"
    , compile_opts => #{ time        => false
-                      , verbose     => false
                       , output_core => false
                       }
    , files        => []
@@ -58,9 +57,6 @@ parse_args([Compile | Rest], Opts)
 parse_args([TimeOpt | Rest], #{compile_opts := CompileOpts} = Opts)
   when TimeOpt =:= "-t"; TimeOpt =:= "--time" ->
   parse_args(Rest, Opts#{compile_opts := CompileOpts#{time := true}});
-parse_args([VerboseOpt | Rest], #{compile_opts := CompileOpts} = Opts)
-  when VerboseOpt =:= "-vv"; VerboseOpt =:= "--verbose" ->
-  parse_args(Rest, Opts#{compile_opts := CompileOpts#{verbose := true}});
 parse_args([File | Rest], Opts = #{files := Files, compile := true}) ->
   parse_args(Rest, Opts#{files => [File | Files]});
 parse_args([Arg | Rest], Opts = #{main_args := MainArgs}) ->
@@ -88,7 +84,7 @@ run_commands(#{ compile      := true
   FilesBin       = [list_to_binary(F) || F <- Files],
   try
     ok = 'clojerl.Var':push_bindings(Bindings),
-    [clj_compiler:compile_file(F, CompileOpts) || F <- FilesBin]
+    [clj_compiler:file(F, CompileOpts) || F <- FilesBin]
   catch ?WITH_STACKTRACE(Type, Reason, Stacktrace)
       handle_error(Type, Reason, Stacktrace)
   after

--- a/test/clj/clojure/test_clojure/compilation.clje
+++ b/test/clj/clojure/test_clojure/compilation.clje
@@ -183,7 +183,7 @@
         (try
           (filelib/ensure_dir tmp)
           (os/putenv #erl"clojerl.compile.path" #erl"tmp")
-          (clj_compiler/compile_file "dummy.clj")
+          (clj_compiler/file "dummy.clj")
           (println "this should still work without throwing an exception" )
           (finally
             (if compile-path

--- a/test/clj/clojure/test_clojure/compilation.clje
+++ b/test/clj/clojure/test_clojure/compilation.clje
@@ -308,7 +308,7 @@
 
 (defn compiler-fails-at? [row col source]
   (try
-    (clj_compiler/compile source)
+    (clj_compiler/string source)
     nil
     (catch :error e
       (let [e  (str e)

--- a/test/clj_compiler_SUITE.erl
+++ b/test/clj_compiler_SUITE.erl
@@ -57,12 +57,12 @@ end_per_testcase(_, Config) ->
 -spec compile(config()) -> result().
 compile(_Config) ->
   ct:comment("Compile code and check a var's value by deref'ing it"),
-  _Env = clj_compiler:compile(<<"(ns src) (def y :hello-world) 1">>),
+  _Env = clj_compiler:string(<<"(ns src) (def y :hello-world) 1">>),
   check_var_value(<<"src">>, <<"y">>, 'hello-world'),
 
   ct:comment("Try to compile invalid code"),
   ok = try
-         clj_compiler:compile(<<"(ns hello) (def 42 :forty-two)">>),
+         clj_compiler:string(<<"(ns hello) (def 42 :forty-two)">>),
          error
        catch _:_ ->
            ok
@@ -144,8 +144,8 @@ eval(_Config) ->
 -spec def_var_compiled_ns(config()) -> result().
 def_var_compiled_ns(_Config) ->
   ct:comment("Defining new var in compiled namespace is persisted"),
-  _ = clj_compiler:compile(<<"(ns examples.simple) (def foo 2)">>),
-  _ = clj_compiler:compile(<<"(ns examples.simple) (def x 1)">>),
+  _ = clj_compiler:string(<<"(ns examples.simple) (def foo 2)">>),
+  _ = clj_compiler:string(<<"(ns examples.simple) (def x 1)">>),
   check_var_value(<<"examples.simple">>, <<"foo">>, 2),
 
   {comments, ""}.

--- a/test/clj_compiler_SUITE.erl
+++ b/test/clj_compiler_SUITE.erl
@@ -11,7 +11,7 @@
         ]).
 
 -export([ compile/1
-        , compile_file/1
+        , file/1
         , eval/1
         , def_var_compiled_ns/1
         ]).
@@ -70,22 +70,22 @@ compile(_Config) ->
 
   {comments, ""}.
 
--spec compile_file(config()) -> result().
-compile_file(_Config) ->
-  Opts = #{verbose => true, time => true},
+-spec file(config()) -> result().
+file(_Config) ->
+  Opts = #{time => true},
   Dir  = <<"scripts/examples">>,
   ct:comment("Compile a file and check a var's value by deref'ing it"),
   SimplePath = clj_test_utils:relative_path(<<Dir/binary, "/simple.clje">>),
-  _Env = clj_compiler:compile_file(SimplePath, Opts),
+  _Env = clj_compiler:file(SimplePath, Opts),
   check_var_value(<<"examples.simple">>, <<"x">>, 1),
 
   ct:comment("Try to compile a non-existen file"),
   NotExistsPath =
     clj_test_utils:relative_path(<<Dir/binary, "/abcdef_42.clje">>),
-  ok = try clj_compiler:compile_file(NotExistsPath, Opts), error
+  ok = try clj_compiler:file(NotExistsPath, Opts), error
        catch _:_ -> ok end,
 
-  Opts     = #{verbose => true, time => true},
+  Opts     = #{time => true},
   SrcPath  = clj_test_utils:relative_path(<<"src/clj">>),
   TestPath = clj_test_utils:relative_path(<<"scripts">>),
   true     = code:add_path(binary_to_list(SrcPath)),
@@ -94,7 +94,7 @@ compile_file(_Config) ->
   ct:comment("Compile two files and use vars from one and the other"),
   SimplePath  = <<TestPath/binary, "/examples/simple.clje">>,
   Simple2Path = <<TestPath/binary, "/examples/simple_2.clje">>,
-  [clj_compiler:compile_file(F, Opts) || F <- [SimplePath, Simple2Path]],
+  [clj_compiler:file(F, Opts) || F <- [SimplePath, Simple2Path]],
 
   check_var_value(<<"examples.simple-2">>, <<"x">>, 1),
 
@@ -103,7 +103,7 @@ compile_file(_Config) ->
   Files2    = filelib:wildcard(binary_to_list(Wildcard2)),
   Exclude   = [clj_test_utils:relative_path(Path) || Path <- ?EXCLUDE_FILES],
   FilesBin2 = lists:map(fun list_to_binary/1, Files2) -- Exclude,
-  [clj_compiler:compile_file(F, Opts) || F <- FilesBin2],
+  [clj_compiler:file(F, Opts) || F <- FilesBin2],
 
   {comments, ""}.
 


### PR DESCRIPTION
### Description

- Make sure that Clojerl source code can be compiled to native code using the `native` compiler option for the Erlang compiler. Because of bugs and limitation in Erlang/OTP (explained in more detailed in #310) compiling to native is only supported in Erlang/OTP 20+.
- Compiled to native code in the pipeline for the supported versions of Erlang/OTP.
- Improve the API of `clj_compiler` and the implementation of some of its functionality.

Closes #310.