### PR TITLE
[#747] Set the io-reader option when calling clj_edn/read

### DIFF
--- a/src/clj/clojure/edn.clje
+++ b/src/clj/clojure/edn.clje
@@ -32,7 +32,7 @@
   ([stream]
    (read {} stream))
   ([opts stream]
-     (clj_edn/read stream opts)))
+   (clj_edn/read "" (->erl (assoc opts :io-reader stream)))))
 
 (defn read-string
   "Reads one object from the string s. Returns nil when s is nil or empty.

--- a/test/clj/clojure/test_clojure/edn.clje
+++ b/test/clj/clojure/test_clojure/edn.clje
@@ -50,3 +50,10 @@
 
 (deftest should-not-roundtrip
   (is (= 0 (:failures (run types-that-should-not-roundtrip)))))
+
+(deftest read-from-reader
+  (let [x (with-open [pbr (-> "{:one 1 :two \"2\"}"
+                              erlang.io.StringReader.
+                              erlang.io.PushbackReader.)]
+            (clojure.edn/read pbr))]
+    (is (= {:one 1 :two "2"} x))))


### PR DESCRIPTION
Fixes #747 