### PR TITLE
Fixed missing \n when reading from a Socket

### DIFF
--- a/src/clj/clojure/core/server.clje
+++ b/src/clj/clojure/core/server.clje
@@ -101,7 +101,7 @@
     (loop [line ""]
       (let [char (unwrap-result (gen_tcp/recv conn 1))]
         (if (= char "\n")
-          line
+          (str line "\n")
           (recur (str line char))))))
   (skip [this length]
     (let [skipped (unwrap-result (gen_tcp/recv conn length))]


### PR DESCRIPTION
Fixes https://github.com/clojerl/clojerl/issues/768

Maybe we should add a testcase for this issue?

Anyway, the fix was quite simple: if the last `char` was `\n`, the line was emitted but did not include `\n` on it.