### PR TITLE
[#772] Handle empty reader buffer when processing escaped chars in regex

### DIFF
--- a/test/clj_reader_SUITE.erl
+++ b/test/clj_reader_SUITE.erl
@@ -875,8 +875,16 @@ regex(ReadFun, ReadAllFun) ->
   Regex2 = 'erlang.util.Regex':?CONSTRUCTOR(<<"">>),
   Regex2 = ReadFun(<<"#\"\"">>),
 
+  Regex3 = 'erlang.util.Regex':?CONSTRUCTOR(<<"foo\\\"">>),
+  Regex3 = ReadFun(<<"#\"foo\\\"\"">>),
+
   ct:comment("EOF: unterminated regex"),
   ok = try ReadAllFun(<<"#\"a*">>)
+       catch _:_ -> ok
+       end,
+
+  ct:comment("EOF: unterminated regex"),
+  ok = try ReadAllFun(<<"#\"foo\\">>)
        catch _:_ -> ok
        end,
 


### PR DESCRIPTION
Fixes #772 