### PR TITLE
[#778] Correctly handle fn returned by macro and used as root binding for var

### DIFF
--- a/scripts/examples/fn.clje
+++ b/scripts/examples/fn.clje
@@ -362,3 +362,12 @@
 
 (def call-no-args-fn-with-one-arg
   (fn* [] (no-args-fn 1)))
+
+;; [#778] fn returned by macro
+
+(def ^{:macro true} return-fn
+  (fn* [_&form _&env & body]
+    (fn* [x] x)))
+
+(should-throw
+ (def def- (return-fn)))

--- a/src/erl/clj_emitter.erl
+++ b/src/erl/clj_emitter.erl
@@ -131,7 +131,10 @@ ast(#{op := def} = Expr, State) ->
         };
       _ ->
         {InitAst0, StateTemp} = pop_ast(ast(InitExpr, State)),
-        InitAst = case cerl:is_literal(InitAst0) of
+        InitAst = case
+                    cerl:is_literal(InitAst0)
+                    andalso cerl:is_literal_term(InitAst0)
+                  of
                      true  -> InitAst0;
                      false ->
                       Init = clj_compiler:eval_expressions([InitAst0]),


### PR DESCRIPTION
Fixes #778 