### PR TITLE
Support Erlang/OTP 28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [24, 25, 26, 27]
+        otp-version: [24, 25, 26, 27, 28]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Cache Hex packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/hex/hexpm/packages
         key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
         restore-keys: |
           ${{ runner.os }}-hex-
     - name: Cache Dialyzer PLTs
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/rebar3_*_plt
         key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}

--- a/src/erl/erlang/erlang.util.Regex.erl
+++ b/src/erl/erlang/erlang.util.Regex.erl
@@ -18,15 +18,15 @@
 -export_type([type/0]).
 -type type() :: #{ ?TYPE   => ?M
                  , pattern => binary()
-                 , regex   => any()
+                 , regex   => binary()
                  }.
 
 -spec ?CONSTRUCTOR(binary()) -> type().
 ?CONSTRUCTOR(Pattern) when is_binary(Pattern) ->
-  {ok, Regex} = re:compile(Pattern),
+  {ok, _} = re:compile(Pattern),
   #{ ?TYPE   => ?M
    , pattern => Pattern
-   , regex   => Regex
+   , regex   => Pattern
    }.
 
 -spec run(type(), binary(), [term()]) ->

--- a/src/erl/lang/clojerl.String.erl
+++ b/src/erl/lang/clojerl.String.erl
@@ -169,6 +169,8 @@ length(Str) ->
   end.
 
 -spec split(binary(), binary()) -> [binary()].
+split(<<>>, _Pattern) ->
+  [<<>>];
 split(Str, Pattern) ->
   split(Str, Pattern, [{return, binary}]).
 

--- a/test/clojerl_String_SUITE.erl
+++ b/test/clojerl_String_SUITE.erl
@@ -156,6 +156,7 @@ substring(_Config) ->
 split(_Config) ->
   [<<"h">>, <<"llo">>] = 'clojerl.String':split(<<"hello">>, <<"e">>),
   [<<"1">>, <<"2">>, <<"3">>] = 'clojerl.String':split(<<"1,2,3">>, <<",">>),
+  [<<>>] = 'clojerl.String':split(<<>>, <<",">>),
 
   {comments, ""}.
 


### PR DESCRIPTION
## Summary

- Add Erlang/OTP 28 to the Linux CI matrix.
- Keep regex literals portable across OTP 27 and 28.
- Preserve Clojerl's empty-string split behavior on OTP 28.

## Problem

OTP 28 represents compiled regular expressions with references. Clojerl's reader stored those compiled values in regex literals, but Core Erlang cannot embed references as literals. The build therefore failed while compiling `clojure/core.clje`.

OTP 28 also changed `re:split(<<>>, ...)` to return `[]`. Clojerl expected `[<<>>]`; the changed result propagated `nil` into the pprint column writer and caused 41 pprint test errors.

## Implementation

`erlang.util.Regex` still calls `re:compile/1` when constructing a regex, so invalid patterns fail at the same point. It stores the validated source binary instead of the OTP-specific compiled term. Erlang's `re:run`, `re:replace`, and `re:split` APIs accept that binary directly.

`clojerl.String:split/2` now returns `[<<>>]` for an empty input, matching Clojerl's existing behavior on OTP 27. The three-argument wrapper remains unchanged.

No Clojerl compiler code changed.

## Validation

- OTP 28: `make ci`
- OTP 27: clean `make`
- OTP 27 and 28: `erlang_util_Regex_SUITE` (5 tests)
- OTP 27 and 28: `clojerl_String_SUITE` (14 tests)
- OTP 27 and 28: regex smoke test, `(re-find #"a+" "caa")` returned `"aa"`